### PR TITLE
Replace ternary operator by ifelse in generic expressions

### DIFF
--- a/docs/chapters/3.1_generic_expressions.md
+++ b/docs/chapters/3.1_generic_expressions.md
@@ -14,7 +14,7 @@ The implementations that support generic expression [must]{.smallcaps} support:
 -   The comparison operators approximately-equal (`x == y`),     exactly-equal (`x === y`), not-approximately-equal (`x != y`),     not-exactly-equal (`x !== y`), less-than (`x < y`), less-or-equal     (`x <= y`), greater-than (`x > y`) and greater-or-equal (`x >= y`). 
 -   The logical operators logical-inverse (`!a`), logical-and     (`a && b`) and logical-or (`a || b`). 
 -   Round brackets to specify the order of operations. 
--   The ternary operator `condition ? result_if_true : result_if_false` 
+-   The conditional expression `ifelse(condition, result_if_true, result_if_false)`
 -   The functions 
     -   `exp(x)`: Euler's number raised to the power of `x` 
     -   `log(x)`: Natural logarithm of `x` 

--- a/docs/chapters/3.1_generic_expressions.md
+++ b/docs/chapters/3.1_generic_expressions.md
@@ -38,6 +38,6 @@ Division [must]{.smallcaps} be treated as floating-point division (i.e. `2/3` sh
 
 The approximately-equal (`a == b`) and the not-approximately-equal operator (`a != b`), [should]{.smallcaps} compare floating-point numbers to within a small multiple of the unit of least precision. 
 
-For the conditional expressions, the order and precedence of evaluation of `condition`, `result_if_true` and `result_if_false` may be freely chosen by the engine.
+Conditional expression may be evaluated in a lazy fashion (evaluating either  `result_if_true` or `result_if_false` depending on the result of `condition`) or in an eager fashion (evaluating all of  `condition`, `result_if_true`  and `result_if_false` in arbitrary order). Evaluation strategy is left to the engine. This implies that on some engines, large trees of conditional expressions may have a high evaluation cost.
 
 The behavior of any functions and operators not listed above is not defined, they are reserved for future versions of this standard. Implementations [may]{.smallcaps} support additional functions and operators as experimental features, but their use is considered non-standard and results in non-portable and potentially non-forward-compatible HS${}^3$ documents. 

--- a/docs/chapters/3.1_generic_expressions.md
+++ b/docs/chapters/3.1_generic_expressions.md
@@ -14,7 +14,7 @@ The implementations that support generic expression [must]{.smallcaps} support:
 -   The comparison operators approximately-equal (`x == y`),     exactly-equal (`x === y`), not-approximately-equal (`x != y`),     not-exactly-equal (`x !== y`), less-than (`x < y`), less-or-equal     (`x <= y`), greater-than (`x > y`) and greater-or-equal (`x >= y`). 
 -   The logical operators logical-inverse (`!a`), logical-and     (`a && b`) and logical-or (`a || b`). 
 -   Round brackets to specify the order of operations. 
--   The conditional expression `ifelse(condition, result_if_true, result_if_false)`
+-   The conditional expression `ifelse(condition, result_if_true, result_if_false)`.
 -   The functions 
     -   `exp(x)`: Euler's number raised to the power of `x` 
     -   `log(x)`: Natural logarithm of `x` 
@@ -37,4 +37,7 @@ Spaces between operators and operands are optional. There must be no space betwe
 Division [must]{.smallcaps} be treated as floating-point division (i.e. `2/3` should be equivalent to `2.0/3.0`). 
 
 The approximately-equal (`a == b`) and the not-approximately-equal operator (`a != b`), [should]{.smallcaps} compare floating-point numbers to within a small multiple of the unit of least precision. 
+
+For the conditional expressions, the order and precedence of evaluation of `condition`, `result_if_true` and `result_if_false` may be freely chosen by the engine.
+
 The behavior of any functions and operators not listed above is not defined, they are reserved for future versions of this standard. Implementations [may]{.smallcaps} support additional functions and operators as experimental features, but their use is considered non-standard and results in non-portable and potentially non-forward-compatible HS${}^3$ documents. 


### PR DESCRIPTION
`ifelse` will be more parser friendly and doesn't carry the C++-implication of "only one branch will be evaluated". HS3 engines should be free to choose if they want to do eager or lazy evaluation.