### PR TITLE
Introduce factorized normalization for `product_dist`

### DIFF
--- a/docs/chapters/1_introduction.md
+++ b/docs/chapters/1_introduction.md
@@ -6,7 +6,9 @@ bibliography: hs3.bib
 *This section is non-normative.* 
 
 It is widely agreed upon that the publication of likelihood models from high energy physics experiments is imperative for the preservation and public access to these results. Detailed arguments have been made elsewhere already [@Cranmer_2022]. This document sets out to provide a standardized format to publish and archive statistical models of any size and across a wide range of mathematical formalisms in a way that is readable by both humans and machines. 
+
 With the introduction of `pyhf` [@pyhf; @pyhf-joss], a `JSON` format for likelihood serialization has been put forward. However, an interoperable format that encompasses likelihoods with a scope beyond stacks of binned histograms was lacking. With the release of `ROOT` 6.26/00 [@root] and the experimental `RooJSONFactoryWSTool` therein, this gap has now been filled. 
+
 This document sets out to document the syntax and features of the Statistics Serialization Standard (HS${}^3$) for likelihoods and statistical models in general, as to be adopted by any HS${}^3$-compatible statistics framework. The examples in this document employ the `JSON` notation, but are intended to encompass also representations as `YAML` or `TOML`. 
 
 ## How to use this document 
@@ -15,14 +17,30 @@ Please note that this document as well as the HS${}^3$ standard are still in dev
 
 ## Statistical semantics of HS${}^3$ {#sec:hs3-semantics} 
 
+A **variable** is a mathematical quantity whose value is chosen or generated,
+rather than directly computed from other quantities. A **parameter** is a
+variable whose value is chosen by a user of the model, such as a minimizer.
+There is no expectation that a distribution is normalized with respect to
+its parameters, or that parameters themselves have specified statistical
+properties or a distribution from which they can be drawn. A **variate**,
+also called an **observable**, is a statistical quantity modeled by a
+distribution; these two terms are used interchangeably in HS${}^3$.
+Both parameters and variates are variables. Their roles are relative to a
+particular use: the same variable may be a parameter in one use and a
+variate in another, for example a parameter of a likelihood model and a
+variate of a prior distribution.
+
 ### Statistical models, probability distributions and parameters {#sec:models-and-parameters} 
+
 HS${}^3$ takes a "forward-modelling" approach throughout: a statistical model $m$ maps a space $\Theta$ of free parameters $\theta$ to a space of probability distributions that describe the possible outcomes of a specific experiment. For any given parameters $\theta$, the model returns a concrete probability distribution $m(\theta)$. Observed data $x$ is then treated as random variate, presumed to be drawn from the model: $x \sim m(\theta)$. 
 Parameters in HS${}^3$ are always named, so semantically the elements of a parameter space $\Theta$ are records $\theta$ (i.e. tuples in which every entry has a name). Even if there is only a single free parameter, $\theta$ should be thought of as a single-entry record. In the current version of this standard, parameter tuples must be flat and only consist of real numbers, vector-valued or nested entries are not supported yet. Future versions of the standard will likely be less restrictive, especially with respect to discrete or vector-valued parameters. Parameter domains defined as part of this standard may be of various types, even though the current version only supports product domains. Future versions are likely to be less restrictive in this regard. 
 Mathematically and computationally, it is often convenient to treat parameters as flat real-valued vectors instead of records, it is the responsibility of the implementation to map between these different views of parameters when and where necessary.
+
 Probability distributions in HS${}^3$ (see 
 [Distributions](#sec:distributions){reference-type="ref" reference="sec:distributions"}) are typically parameterized. Any instance of a distribution that has some of its parameters bound to names instead of concrete values, e.g. $m = d_{\mu = a, \sigma = 0.7, \lambda = b, ...}$, constitutes a valid statistical model $m(\theta)$ with model parameters $\theta = (a, b)$. 
 When probability distributions are combined via a Cartesian product (see 
 [Product distribution](#sec:product-distribution){reference-type="ref" reference="sec:product-distribution"}), then the records that contain their free parameter values are concatenated. So $m = d_{\mu = a, \sigma = b} \times d_{\mu = c, \sigma = 0.7}$ constitutes a model $m(\theta)$ with model parameters $\theta = (a, b, c)$.
+
 Distribution parameters may also be bound to the output of functions, and if those functions have inputs that are bound to names instead of values (or again bound to such functions, recursively), then those names become part of the model parameters. A configuration $m = d_{\mu = a, \sigma = 0.7, \lambda = f}, f = \texttt{sum}(4.2, g), g = \texttt{sum}(1.3, b)$, for example, also constitutes a (different) model $m(\theta)$ with parameters $\theta = (a, b, c)$. 
 If all parameter values of a probability distribution are set to concrete values, so if there are not directly (or indirectly via functions) bound to names, we call this probability distribution a concrete distribution here. Such distributions can be used as Bayesian 
 priors (see [Bayesian inference](#sec:bayesian-inference){reference-type="ref" reference="sec:bayesian-inference"}). 
@@ -40,8 +58,10 @@ multiple HS${}^3$ documents together, e.g. for combined analyses.
 
 ### Probability density functions (PDFs) {#sec:what-is-a-pdf} 
 Statistics literature often discriminates between probability density functions (PDF) for continuous probability distributions and probability mass functions (PMF) for discrete probability distributions. This standard use the term PDF for both continuous and discrete distributions. The concept of density is to be understood in terms of densities in the realm of measure theory here, that is the density of a probability measure (distribution) is its Radon-Nikodym derivative in respect to an (implied) reference measure. 
+
 The choice of reference measure would be arbitrary in principle, which scales likelihood functions 
 (Sec. [Likelihood](#sec:likelihood-definition){reference-type="ref" reference="sec:likelihood-definition"}) by a constant factor that depends on choice of reference. In this standard, a specific reference measures is implied for each probability distribution, typically the Lebesgue measure for continuous distributions and the counting measure for discrete distributions. The standard aims to match the PDF (resp.&nbsp;PMF) most commonly used in literature for each specific probability distribution and the mathematical form of the PDF is documented explicitly for each distribution in the standard. So within HS${}^3$, probability densities and likelihood functions are unambiguous. 
+
 Here we use $\text{PDF}(m(\theta), x)$ to denote the density value of the probability distribution/measure $m$, parameterized by $\theta$, at the point/variate $x$, in respect to the implied reference for $m$. 
 
 ### Observed and simulated data {#sec:data-generation} 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -121,8 +121,9 @@ This can be represented by the product
 ```
 
 Here, $p_1$ is normalized independently over `x`, while the remaining subproduct $p_2 p_3$ is normalized over the remaining observables ($y$ and $z$), so
+
 $$
-\ensuremath{\mathcal{M}}&= \int dx p_1(x, y) \int\int dy dz p_2(y, z) p_3(z)
+\begin{aligned} \ensuremath{\mathcal{M}}&= \int dx p_1(x, y) \int\int dy dz p_2(y, z) p_3(z) \end{aligned} 
 $$
 
 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -66,20 +66,82 @@ If all coefficients are given, their sum is used as the expected number of event
 
 #### Product distribution {#sec:product-distribution label="sec:product-distribution"} 
 
-The product of independent distributions $f_i$ is defined as 
-
-
+The product of distributions $f_i$ is defined as 
 
 $$
-\begin{aligned} \text{ProductPdf}(x) &= \frac{1}{\ensuremath{\mathcal{M}}}\prod_i^n f(x). \end{aligned} 
+\begin{aligned} \text{ProductPdf}(x_0, x_1, \dots) &= \frac{1}{\ensuremath{\mathcal{M}}}\prod_i^n f_i(x_0, x_1, \dots). \end{aligned} 
 $$
 
 
 
--   `name`: custom string 
--   `type`: `product_dist` 
--   `x`: name of the variable $x$ ([optional]{.smallcaps}, since the     variable is fully defined by the factors) 
--   `factors`: array of names referencing distributions 
+-`name`: custom string 
+-`type`: `product_dist` 
+-`x`: array of names of the variables $x$ ([optional]{.smallcaps}, since the variable is fully defined by the factors) 
+-`factors`: array of names referencing distributions 
+-`normalization`: [optional]{.smallcaps} possibility to define the normalization $\ensuremath{\mathcal{M}}$ of the product (see below)
+
+
+A product distribution is by default, interpreted as the product of its factors with a single global normalization over all observables, that is,
+
+$$
+\ensuremath{\mathcal{M}}&= \int d\Omega \prod_i^n f_i(x_0, x_1, \dots) = \int\int\dots dx_1 dx_2 \dots \prod_i^n f_i(x_0, x_1, \dots)
+$$
+
+Here, $d\Omega$ denotes the product measure over all observables in the current analysis context.
+
+The normalization factor $\ensuremath{\mathcal{M}}$ denotes the
+denominator applied to the product distribution.  The optional
+([optional]{.smallcaps} `normalization` field specifies the
+normalization of subproducts by declaring groups of factors that are
+independently normalized over specified observables.  Each entry in
+`normalization` identifies
+
+* a set of factors forming a subproduct, and
+* the observables over which that subproduct is individually normalized.
+
+After all explicitly declared normalization groups have been applied, the remaining factors are multiplied together and normalized over every observable that has not already been assigned to a normalization group.
+When the [optional]{.smallcaps}  `normalization` is used,  $\ensuremath{\mathcal{M}}$ is, in general, no longer a constant but may depend on observables that are not integrated within one or more normalization groups.
+
+This mechanism expresses **conditional probability densities** through the normalization structure of the product, rather than by assigning conditionality to individual distributions.
+
+For example, consider the factorization
+
+$$
+p(x,y,z) = p_1(x,y) p_2(y,z) p_3(z)
+$$
+
+This can be represented by the product
+
+```json
+"type": "product_dist"
+"factors": ["P1", "P2", "P3"]
+"normalization": [
+	{ "factors": [P1], "over": ["x"] }
+]
+```
+
+Here, $p_1$ is normalized independently over `x`, while the remaining subproduct $p_2 p_3$ is normalized over the remaining observables ($y$ and $z$), so
+$$
+\ensuremath{\mathcal{M}}&= \int dx p_1(x, y) \int\int dy dz p_2(y, z) p_3(z)
+$$
+
+
+Note that  $\ensuremath{\mathcal{M}} = \ensuremath{\mathcal{M}}(y)$  is now a function of the observable $y$, which is not integrated during the normalization of the first subproduct. 
+This normalization structure is mathematically equivalent to the conditional factorization
+
+$$
+p(x,y,z) = p_1(x \mid y)\, p_2(y,z)\, p_3(z),
+$$
+
+where the conditional density $p_1(x \mid y)$ is induced by normalizing the first subproduct over $x$. This avoids assigning conditionality as an intrinsic property of the individual distributions, instead expressing it through the normalization structure of the product.
+
+The following constraints apply:
+
+* Each factor [shall]{.smallcaps} appear in at most one `normalization` entry.
+* An observable  [shall]{.smallcaps} be normalized by at most one factorized subproduct.
+* If an observable is normalized by a factorized subproduct, every factor depending on that observable  [shall]{.smallcaps} belong to that same subproduct.
+* Factors and observables not referenced by any entry participate in the implicit global normalization.
+
 
 #### Efficiency product distribution
 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -84,7 +84,7 @@ $$
 A product distribution is by default, interpreted as the product of its factors with a single global normalization over all observables, that is,
 
 $$
-\ensuremath{\mathcal{M}}&= \int d\Omega \prod_i^n f_i(x_0, x_1, \dots) = \int\int\dots dx_1 dx_2 \dots \prod_i^n f_i(x_0, x_1, \dots)
+\begin{aligned} \ensuremath{\mathcal{M}}&= \int d\Omega \prod_i^n f_i(x_0, x_1, \dots) = \int\int\dots dx_1 dx_2 \dots \prod_i^n f_i(x_0, x_1, \dots) \end{aligned} 
 $$
 
 Here, $d\Omega$ denotes the product measure over all observables in the current analysis context.

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -69,7 +69,7 @@ If all coefficients are given, their sum is used as the expected number of event
 The product of distributions $f_i$ is defined as 
 
 $$
-\begin{aligned} \text{ProductPdf}(x_0, x_1, \dots) &= \frac{1}{\ensuremath{\mathcal{M}}}\prod_i^n f_i(x_0, x_1, \dots). \end{aligned} 
+\begin{aligned} \text{ProductPdf}(x_1, x_2, \dots) &= \frac{1}{\ensuremath{\mathcal{M}}}\prod_i^n f_i(x_1, x_2, \dots). \end{aligned} 
 $$
 
 
@@ -84,7 +84,7 @@ $$
 A product distribution is by default, interpreted as the product of its factors with a single global normalization over all observables, that is,
 
 $$
-\begin{aligned} \ensuremath{\mathcal{M}}&= \int d\Omega \prod_i^n f_i(x_0, x_1, \dots) = \int\int\dots dx_1 dx_2 \dots \prod_i^n f_i(x_0, x_1, \dots) \end{aligned} 
+\begin{aligned} \ensuremath{\mathcal{M}}&= \int d\Omega \prod_i^n f_i(x_1, x_2, \dots) = \int\int\dots dx_1 dx_2 \dots \prod_i^n f_i(x_1, x_2, \dots) \end{aligned} 
 $$
 
 Here, $d\Omega$ denotes the product measure over all observables in the current analysis context.

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -104,10 +104,10 @@ When the [optional]{.smallcaps}  `normalization` is used,  $\ensuremath{\mathcal
 
 This mechanism expresses **conditional probability densities** through the normalization structure of the product, rather than by assigning conditionality to individual distributions.
 
-For example, consider the factorization
+For example, consider the unnormalized factorization
 
 $$
-p(x,y,z) = p_1(x,y) p_2(y,z) p_3(z)
+p(x,y,z) \propto p_1(x,y) p_2(y,z) p_3(z).
 $$
 
 This can be represented by the product
@@ -120,21 +120,45 @@ This can be represented by the product
 ]
 ```
 
-Here, $p_1$ is normalized independently over `x`, while the remaining subproduct $p_2 p_3$ is normalized over the remaining observables ($y$ and $z$), so
+Here, $p_1$ is normalized independently over `x`, while the remaining
+subproduct $p_2 p_3$ is normalized over the remaining observables
+($y$ and $z$). The factorized normalization denominator is therefore
 
 $$
-\begin{aligned} \ensuremath{\mathcal{M}}&= \int dx p_1(x, y) \int\int dy dz p_2(y, z) p_3(z) \end{aligned} 
+\begin{aligned}
+\ensuremath{\mathcal{M}}(y)
+&=
+\left[\int dx\,p_1(x,y)\right]
+\left[\int\!\!\int dy\,dz\,p_2(y,z)p_3(z)\right].
+\end{aligned}
 $$
 
-
-Note that  $\ensuremath{\mathcal{M}} = \ensuremath{\mathcal{M}}(y)$  is now a function of the observable $y$, which is not integrated during the normalization of the first subproduct. 
-This normalization structure is mathematically equivalent to the conditional factorization
+Note that $\ensuremath{\mathcal{M}}=\ensuremath{\mathcal{M}}(y)$ is now
+a function of $y$, which is not integrated during the normalization of
+the first subproduct. The distribution encoded by this normalization
+structure is
 
 $$
-p(x,y,z) = p_1(x \mid y)\, p_2(y,z)\, p_3(z),
+\begin{aligned}
+p(x,y,z)
+&=
+\frac{p_1(x,y)}
+     {\int dx\,p_1(x,y)}
+\,
+\frac{p_2(y,z)p_3(z)}
+     {\int\!\!\int dy\,dz\,p_2(y,z)p_3(z)}
+\\
+&=
+p_1(x\mid y)\,p(y,z).
+\end{aligned}
 $$
 
-where the conditional density $p_1(x \mid y)$ is induced by normalizing the first subproduct over $x$. This avoids assigning conditionality as an intrinsic property of the individual distributions, instead expressing it through the normalization structure of the product.
+Here, the conditional density $p_1(x\mid y)$ is induced by normalizing
+the first subproduct over $x$, and $p(y,z)$ is the remaining subproduct
+$p_2(y,z)p_3(z)$ normalized over $y$ and $z$. This is the chain-rule
+factorization of the normalized joint distribution. It avoids assigning
+conditionality as an intrinsic property of an individual distribution,
+instead expressing it through the normalization structure of the product.
 
 The following constraints apply:
 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -66,43 +66,50 @@ If all coefficients are given, their sum is used as the expected number of event
 
 #### Product distribution {#sec:product-distribution label="sec:product-distribution"} 
 
-The product of distributions $f_i$ is defined as 
+The product of independent distributions $f_i$ is defined as
 
 $$
-\begin{aligned} \text{ProductPdf}(x_1, x_2, \dots) &= \frac{1}{\ensuremath{\mathcal{M}}}\prod_i^n f_i(x_1, x_2, \dots). \end{aligned} 
+\begin{aligned} \text{ProductPdf}(x) &= \frac{1}{\ensuremath{\mathcal{M}}}\prod_i^n f_i(x). \end{aligned}
 $$
 
+-   `name`: custom string
+-   `type`: `product_dist`
+-   `x`: name of the variable $x$ ([optional]{.smallcaps}, since the variable is fully defined by the factors)
+-   `factors`: array of names referencing distributions
+
+The variates of the factors [must]{.smallcaps} be pairwise disjoint. Consequently, the normalization factorizes into the product of the normalizations of the factors. This structure permits efficient normalization and sampling by treating every factor independently.
 
 
--`name`: custom string 
--`type`: `product_dist` 
--`x`: array of names of the variables $x$ ([optional]{.smallcaps}, since the variable is fully defined by the factors) 
--`factors`: array of names referencing distributions 
--`normalization`: [optional]{.smallcaps} possibility to define the normalization $\ensuremath{\mathcal{M}}$ of the product (see below)
+#### Point-product distribution {#sec:point-product-distribution label="sec:point-product-distribution"}
 
-
-A product distribution is by default, interpreted as the product of its factors with a single global normalization over all observables, that is,
+A point-product distribution is the normalized pointwise product of distributions whose variates may overlap:
 
 $$
-\begin{aligned} \ensuremath{\mathcal{M}}&= \int d\Omega \prod_i^n f_i(x_1, x_2, \dots) = \int\int\dots dx_1 dx_2 \dots \prod_i^n f_i(x_1, x_2, \dots) \end{aligned} 
+\begin{aligned}
+\text{PointProductPdf}(x_1, x_2, \dots)
+&= \frac{1}{\ensuremath{\mathcal{M}}}
+   \prod_{i=1}^{n} f_i(x_1, x_2, \dots).
+\end{aligned}
 $$
 
-Here, $d\Omega$ denotes the product measure over all observables in the current analysis context (see Section [Analyses](#sec:analyses)).
+-   `name`: custom string
+-   `type`: `point_product_dist`
+-   `x`: array of names of the variables $x$ ([optional]{.smallcaps}, since the variables are fully defined by the factors)
+-   `factors`: array of names referencing distributions
+-   `conditionals`: [optional]{.smallcaps} array declaring conditional subproducts (see below)
 
-The normalization factor $\ensuremath{\mathcal{M}}$ denotes the
-denominator applied to the product distribution.  The optional
-([optional]{.smallcaps} `normalization` field specifies the
-normalization of subproducts by declaring groups of factors that are
-independently normalized over specified observables.  Each entry in
-`normalization` identifies
+Without `conditionals`, the product has a single global normalization over all its variates. In an analysis context, only variables interpreted as observables are integrated; variables interpreted as parameters are held fixed (see Section [Analyses](#sec:analyses)). Thus,
 
-* a set of factors forming a subproduct, and
-* the observables over which that subproduct is individually normalized.
+$$
+\begin{aligned}
+\ensuremath{\mathcal{M}}
+&= \int d\Omega\,\prod_{i=1}^{n} f_i(x_1, x_2, \dots),
+\end{aligned}
+$$
 
-After all explicitly declared normalization groups have been applied, the remaining factors are multiplied together and normalized over every observable that has not already been assigned to a normalization group.
-When the [optional]{.smallcaps}  `normalization` is used,  $\ensuremath{\mathcal{M}}$ is, in general, no longer a constant but may depend on observables that are not integrated within one or more normalization groups.
+where $d\Omega$ denotes the product measure over those observables.
 
-This mechanism expresses **conditional probability densities** through the normalization structure of the product, rather than by assigning conditionality to individual distributions.
+Each entry in `conditionals` declares a group of `factors` to be a conditional subproduct and uses `on` to name its conditioning variables. For such a group $G$ with conditioning variables $C_G$, all observables of $G$ other than those in $C_G$ are integrated in its normalization, while the variables in $C_G$ are held fixed. The resulting factor is therefore a conditional density. Factors not assigned to a conditional group form one remaining subproduct, which is normalized jointly over all observables not normalized by a conditional group.
 
 For example, consider the unnormalized factorization
 
@@ -113,30 +120,16 @@ $$
 This can be represented by the product
 
 ```json
-"type": "product_dist"
-"factors": ["P1", "P2", "P3"]
-"normalization": [
-	{ "factors": ["P1"], "over": ["x"] }
-]
+{
+  "type": "point_product_dist",
+  "factors": ["P1", "P2", "P3"],
+  "conditionals": [
+    { "factors": ["P1"], "on": ["y"] }
+  ]
+}
 ```
 
-Here, $p_1$ is normalized independently over `x`, while the remaining
-subproduct $p_2 p_3$ is normalized over the remaining observables
-($y$ and $z$). The factorized normalization denominator is therefore
-
-$$
-\begin{aligned}
-\ensuremath{\mathcal{M}}(y)
-&=
-\left[\int dx\,p_1(x,y)\right]
-\left[\int\!\!\int dy\,dz\,p_2(y,z)p_3(z)\right].
-\end{aligned}
-$$
-
-Note that $\ensuremath{\mathcal{M}}=\ensuremath{\mathcal{M}}(y)$ is now
-a function of $y$, which is not integrated during the normalization of
-the first subproduct. The distribution encoded by this normalization
-structure is
+Here, $p_1$ is conditional on $y$ and is therefore normalized over $x$ while holding $y$ fixed. The remaining subproduct $p_2p_3$ is normalized jointly over $y$ and $z$. The complete distribution is
 
 $$
 \begin{aligned}
@@ -153,22 +146,16 @@ p_1(x\mid y)\,p(y,z).
 \end{aligned}
 $$
 
-Here, the conditional density $p_1(x\mid y)$ is induced by normalizing
-the first subproduct over $x$, and $p(y,z)$ is the remaining subproduct
-$p_2(y,z)p_3(z)$ normalized over $y$ and $z$. This is the chain-rule
-factorization of the normalized joint distribution. It avoids assigning
-conditionality as an intrinsic property of an individual distribution,
-instead expressing it through the normalization structure of the product.
+This is distinct from a globally normalized two-variable distribution $p_1(x,y)$: the conditional declaration explicitly defines $p_1(x\mid y)$. Conditionality belongs to the point-product structure rather than to the referenced distribution, so the same distribution may be used conditionally in one product and jointly in another.
 
 The following constraints apply:
 
-* Each factor [shall]{.smallcaps} appear in at most one `normalization` entry.
-* An observable  [shall]{.smallcaps} be normalized by at most one factorized subproduct.
-* If an observable is normalized by a factorized subproduct, every factor depending on that observable  [shall]{.smallcaps} belong to that same subproduct.
-* Every `normalization` entry's `factors` [shall]{.smallcaps} form a subset of the enclosing product's `factors`.
-* Every observable listed in `over` [shall]{.smallcaps} appear as a variable of at least one factor referenced by the same `normalization` entry.
-
-* Factors and observables not referenced by any entry participate in the implicit global normalization.
+* Each factor [shall]{.smallcaps} appear in at most one `conditionals` entry.
+* Every `conditionals` entry's `factors` [shall]{.smallcaps} be a non-empty subset of the enclosing point product's `factors`.
+* Every variable listed in `on` [shall]{.smallcaps} be a variate of at least one factor referenced by the same `conditionals` entry.
+* An observable [shall]{.smallcaps} be integrated by at most one conditional or remaining subproduct.
+* If an observable is integrated by a conditional subproduct, every factor depending on that observable [shall]{.smallcaps} belong to that same subproduct.
+* Factors and observables not assigned to a conditional subproduct participate in the remaining joint normalization.
 
 
 #### Efficiency product distribution

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -165,6 +165,9 @@ The following constraints apply:
 * Each factor [shall]{.smallcaps} appear in at most one `normalization` entry.
 * An observable  [shall]{.smallcaps} be normalized by at most one factorized subproduct.
 * If an observable is normalized by a factorized subproduct, every factor depending on that observable  [shall]{.smallcaps} belong to that same subproduct.
+* Every `normalization` entry's `factors` [shall]{.smallcaps} form a subset of the enclosing product's `factors`.
+* Every observable listed in `over` [shall]{.smallcaps} appear as a variable of at least one factor referenced by the same `normalization` entry.
+
 * Factors and observables not referenced by any entry participate in the implicit global normalization.
 
 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -77,28 +77,12 @@ $$
 -   `x`: name of the variable $x$ ([optional]{.smallcaps}, since the variable is fully defined by the factors)
 -   `factors`: array of names referencing distributions
 
-The variates of the factors [must]{.smallcaps} be pairwise disjoint. Consequently, the normalization factorizes into the product of the normalizations of the factors. This structure permits efficient normalization and sampling by treating every factor independently.
+The variates of the factors [must]{.smallcaps} be pairwise
+disjoint. Consequently, the normalization factorizes into the product
+of the normalizations of the factors. This structure permits efficient
+normalization and sampling by treating every factor independently.
 
-
-#### Point-product distribution {#sec:point-product-distribution label="sec:point-product-distribution"}
-
-A point-product distribution is the normalized pointwise product of distributions whose variates may overlap:
-
-$$
-\begin{aligned}
-\text{PointProductPdf}(x_1, x_2, \dots)
-&= \frac{1}{\ensuremath{\mathcal{M}}}
-   \prod_{i=1}^{n} f_i(x_1, x_2, \dots).
-\end{aligned}
-$$
-
--   `name`: custom string
--   `type`: `point_product_dist`
--   `x`: array of names of the variables $x$ ([optional]{.smallcaps}, since the variables are fully defined by the factors)
--   `factors`: array of names referencing distributions
--   `conditionals`: [optional]{.smallcaps} array declaring conditional subproducts (see below)
-
-Without `conditionals`, the product has a single global normalization over all its variates. In an analysis context, only variables interpreted as observables are integrated; variables interpreted as parameters are held fixed (see Section [Analyses](#sec:analyses)). Thus,
+In an analysis context, only variables interpreted as observables are integrated; variables interpreted as parameters are held fixed (see Section [Analyses](#sec:analyses)). Thus,
 
 $$
 \begin{aligned}
@@ -109,17 +93,51 @@ $$
 
 where $d\Omega$ denotes the product measure over those observables.
 
-Each entry in `conditionals` declares a group of `factors` to be a conditional subproduct and uses `on` to name its conditioning variables. For such a group $G$ with conditioning variables $C_G$, all observables of $G$ other than those in $C_G$ are integrated in its normalization, while the variables in $C_G$ are held fixed. The resulting factor is therefore a conditional density. Factors not assigned to a conditional group form one remaining subproduct, which is normalized jointly over all observables not normalized by a conditional group.
+For other types of products, please refer to the [Point-product distribution](#sec:point-product-distribution) or the [Product function](#sec:product-function).
 
-For example, consider the unnormalized factorization
+#### Point-product distribution {#sec:point-product-distribution label="sec:point-product-distribution"}
+
+A point-product distribution is the normalized pointwise product of distributions whose variates may overlap:
 
 $$
-p(x,y,z) \propto p_1(x,y) p_2(y,z) p_3(z).
+\text{PointProductPdf}(x_1,x_2,\dots)
+=
+\frac{1}{\ensuremath{\mathcal{M}}}
+\prod_{i=1}^{n} f_i(x_1,x_2,\dots).
 $$
 
-This can be represented by the product
+* `name`: custom string
+* `type`: `point_product_dist`
+* `x`: array of names of the variables $x$ ([optional]{.smallcaps}, since the variables are fully defined by the factors)
+* `factors`: array of names referencing distributions
+* `conditionals`: [optional]{.smallcaps} array declaring conditional subproducts
 
-```json
+Without `conditionals`, the product has a single global normalization and is identical to the simpler [Product distribution](#sec:product-distribution), which should be used instead.
+
+In an analysis context, only variables interpreted as observables are integrated; variables interpreted as parameters are held fixed (see Section [Analyses](#sec:analyses)).
+
+Each entry in `conditionals` declares a group of `factors` to be a conditional subproduct and uses `on` to name the variables on which it is conditioned. The subproduct is normalized first while holding the variables listed in `on` fixed. The resulting conditional density replaces the corresponding factors in the complete point product, which is then normalized globally over all observables.
+
+Thus, for a conditional group $G$ with conditioning variables $C_G$,
+
+$$
+\widetilde q_G
+=
+\frac{\prod_{f_i\in G} f_i}
+     {\int d\Omega_G\,\prod_{f_i\in G} f_i},
+$$
+
+where $d\Omega_G$ integrates the observable variates of $G$ except those in $C_G$.
+
+For example,
+
+$$
+p(x,y,z)\propto p_1(x,y)p_2(y,z)p_3(z)
+$$
+
+may be represented as
+
+```json id="7u6e8l"
 {
   "type": "point_product_dist",
   "factors": ["P1", "P2", "P3"],
@@ -129,33 +147,40 @@ This can be represented by the product
 }
 ```
 
-Here, $p_1$ is conditional on $y$ and is therefore normalized over $x$ while holding $y$ fixed. The remaining subproduct $p_2p_3$ is normalized jointly over $y$ and $z$. The complete distribution is
+Here, `on: ["y"]` means that $y$ is held fixed while $p_1(x,y)$ is normalized over $x$, giving
 
 $$
-\begin{aligned}
-p(x,y,z)
-&=
+p_1(x\mid y)
+=
 \frac{p_1(x,y)}
-     {\int dx\,p_1(x,y)}
-\,
+     {\int dx\,p_1(x,y)}.
+$$
+
+The complete product is therefore
+
+$$
+p_1(x\mid y)p_2(y,z)p_3(z),
+$$
+
+which is subsequently normalized over $x$, $y$, and $z$. Since $p_1(x\mid y)$ is already normalized over $x$ for fixed $y$, this reduces to
+
+$$
+p(x,y,z)
+=
+p_1(x\mid y)\,
 \frac{p_2(y,z)p_3(z)}
      {\int\!\!\int dy\,dz\,p_2(y,z)p_3(z)}
-\\
-&=
+=
 p_1(x\mid y)\,p(y,z).
-\end{aligned}
 $$
 
-This is distinct from a globally normalized two-variable distribution $p_1(x,y)$: the conditional declaration explicitly defines $p_1(x\mid y)$. Conditionality belongs to the point-product structure rather than to the referenced distribution, so the same distribution may be used conditionally in one product and jointly in another.
+Conditionality belongs to the point-product structure rather than to the referenced distribution, so the same distribution may be used conditionally in one point product and jointly in another.
 
 The following constraints apply:
 
 * Each factor [shall]{.smallcaps} appear in at most one `conditionals` entry.
 * Every `conditionals` entry's `factors` [shall]{.smallcaps} be a non-empty subset of the enclosing point product's `factors`.
 * Every variable listed in `on` [shall]{.smallcaps} be a variate of at least one factor referenced by the same `conditionals` entry.
-* An observable [shall]{.smallcaps} be integrated by at most one conditional or remaining subproduct.
-* If an observable is integrated by a conditional subproduct, every factor depending on that observable [shall]{.smallcaps} belong to that same subproduct.
-* Factors and observables not assigned to a conditional subproduct participate in the remaining joint normalization.
 
 
 #### Efficiency product distribution

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -116,7 +116,7 @@ This can be represented by the product
 "type": "product_dist"
 "factors": ["P1", "P2", "P3"]
 "normalization": [
-	{ "factors": [P1], "over": ["x"] }
+	{ "factors": ["P1"], "over": ["x"] }
 ]
 ```
 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -66,79 +66,151 @@ If all coefficients are given, their sum is used as the expected number of event
 
 #### Product distribution {#sec:product-distribution label="sec:product-distribution"} 
 
-The product of independent distributions $f_i$ is defined as
+A product distribution is the Cartesian product of its factor distributions.
+For a particular use, let $\vec{x}_i$ denote the variates of factor $i$ and
+$\theta$ denote the parameters of the product. Its density is
 
 $$
-\begin{aligned} \text{ProductPdf}(x) &= \frac{1}{\ensuremath{\mathcal{M}}}\prod_i^n f_i(x). \end{aligned}
+\text{ProductPdf}(\vec{x}_1,\ldots,\vec{x}_n;\theta)
+=\prod_{i=1}^{n} f_i(\vec{x}_i;\theta),
 $$
+
+where each factor is normalized over its variates on the applicable domain,
+with the parameters held fixed.
 
 -   `name`: custom string
 -   `type`: `product_dist`
--   `x`: name of the variable $x$ ([optional]{.smallcaps}, since the variable is fully defined by the factors)
--   `factors`: array of names referencing distributions
+-   `factors`: non-empty array of unique names referencing existing distributions
 
-The variates of the factors [must]{.smallcaps} be pairwise
-disjoint. Consequently, the normalization factorizes into the product
-of the normalizations of the factors. This structure permits efficient
-normalization and sampling by treating every factor independently.
+The variates of the factors [must]{.smallcaps} be pairwise disjoint for
+this use. Each factor may depend on its own variates and on the parameters
+of the product, but not on another factor's variates. This includes
+dependencies through functions or through fields such as a Gaussian's
+`mean`. Factors may share parameters.
+Their variate records are concatenated in the product.
 
-In an analysis context, only variables interpreted as observables are integrated; variables interpreted as parameters are held fixed (see Section [Analyses](#sec:analyses)). Thus,
-
-$$
-\begin{aligned}
-\ensuremath{\mathcal{M}}
-&= \int d\Omega\,\prod_{i=1}^{n} f_i(x_1, x_2, \dots),
-\end{aligned}
-$$
-
-where $d\Omega$ denotes the product measure over those observables.
+On the product of the factors' domains, the product of their normalized
+densities is already normalized. No additional normalization factor is
+needed. For any fixed choice of the parameters, the groups of variates are
+independent, allowing each factor to be normalized and sampled independently.
+The choice of variates is determined by the use of the distribution as
+described in Section [Distributions](#sec:distributions).
 
 For other types of products, please refer to the [Point-product distribution](#sec:point-product-distribution) or the [Product function](#sec:product-function).
 
 #### Point-product distribution {#sec:point-product-distribution label="sec:point-product-distribution"}
 
-A point-product distribution is the normalized pointwise product of distributions whose variates may overlap:
+A point-product distribution combines densities by pointwise multiplication,
+allowing the variates of its factors to overlap. Groups of factors may be
+used conditionally on specified variables before the complete product is
+normalized.
 
-$$
-\text{PointProductPdf}(x_1,x_2,\dots)
-=
-\frac{1}{\ensuremath{\mathcal{M}}}
-\prod_{i=1}^{n} f_i(x_1,x_2,\dots).
-$$
+Factors may share both variates and parameters. The product is normalized
+over its variates, with its parameters held fixed.
 
 * `name`: custom string
 * `type`: `point_product_dist`
-* `x`: array of names of the variables $x$ ([optional]{.smallcaps}, since the variables are fully defined by the factors)
-* `factors`: array of names referencing distributions
+* `factors`: non-empty array of unique names referencing existing distributions
 * `conditionals`: [optional]{.smallcaps} array declaring conditional subproducts
 
-Without `conditionals`, the product has a single global normalization and is identical to the simpler [Product distribution](#sec:product-distribution), which should be used instead.
+Each entry in `conditionals` is an object with the following fields:
 
-In an analysis context, only variables interpreted as observables are integrated; variables interpreted as parameters are held fixed (see Section [Analyses](#sec:analyses)).
+* `factors`: [required]{.smallcaps} non-empty array of unique references to factors of the enclosing point product.
+* `on`: [required]{.smallcaps} array of unique variable names on which the group depends, including dependencies through functions. This array may be empty.
 
-Each entry in `conditionals` declares a group of `factors` to be a conditional subproduct and uses `on` to name the variables on which it is conditioned. The subproduct is normalized first while holding the variables listed in `on` fixed. The resulting conditional density replaces the corresponding factors in the complete point product, which is then normalized globally over all observables.
+An empty `conditionals` array is equivalent to omitting the field. An empty
+`on` array declares normalization over all variates of the group for the
+particular use, with its parameters held fixed.
 
-Thus, for a conditional group $G$ with conditioning variables $C_G$,
+Without `conditionals`, the distribution is the globally normalized
+pointwise product of its factors. When the factors satisfy the requirements
+of [Product distribution](#sec:product-distribution), the two constructions
+agree. Factors with overlapping sets of variates, such as $f_1(x)f_2(x)$, require a
+`point_product_dist` even when no conditional subproducts are declared.
+
+Each entry in `conditionals` declares that a group of `factors` is used
+conditionally on the variables listed in `on`. For a particular use, the
+product of those factors is normalized over the variates on which it
+depends, excluding any listed in `on`. All parameters and all variables
+listed in `on` are held fixed during this integration. The resulting
+conditional density replaces that group in the enclosing point product.
+The complete point product is then normalized over all its variates, with
+its parameters held fixed.
+
+These declarations apply to the factors' use within this point product;
+they do not change the referenced distributions in other uses. A variable
+listed in `on` may be a variate in one use and a parameter in another. If
+it is a variate, it is excluded from the group's normalization integral
+but included in the complete product's normalization integral. If it is
+a parameter, it is held fixed in both integrals. Parameters are excluded
+from both integrals regardless of whether they appear in `on`. The choice
+of variates is determined by the use of the distribution as described in
+Section [Distributions](#sec:distributions).
+
+If no variates remain in a conditional group's normalization integral,
+the conditional factor is defined to be identically one, including at
+points where the product of its factors is zero.
+
+More precisely, let $V$ be the set of variates of the enclosing product for
+this use. Let $I$ index all factors, $\mathcal{G}$ be the collection of
+conditional factor groups, and $R$ index the factors outside those groups.
+For each group $G$, let $D_G$ be the set of variables on which its factors
+depend, including dependencies through fields such as a Gaussian's `mean`
+and through functions,
+and let $C_G$ be the variables listed in `on`. The group's conditional
+density is
 
 $$
-\widetilde q_G
-=
-\frac{\prod_{f_i\in G} f_i}
-     {\int d\Omega_G\,\prod_{f_i\in G} f_i},
+\begin{aligned}
+U_G &= (V\cap D_G)\setminus C_G,\\
+q_G &=
+\begin{cases}
+1, & U_G=\varnothing,\\[4pt]
+\displaystyle\frac{\prod_{i\in G}f_i}{Z_G}, & U_G\ne\varnothing.
+\end{cases}
+\end{aligned}
 $$
 
-where $d\Omega_G$ integrates the observable variates of $G$ except those in $C_G$.
-
-For example,
+where, for $U_G\ne\varnothing$,
 
 $$
-p(x,y,z)\propto p_1(x,y)p_2(y,z)p_3(z)
+Z_G = \int \prod_{i\in G}f_i\,d\mu_{U_G}.
 $$
 
-may be represented as
+Here $d\mu_{U_G}$ denotes integration over the variates in $U_G$ on their
+applicable domain, using their reference measures. All parameters and all
+variables listed in `on` are held fixed. Thus $Z_G$ may depend on the
+conditioning variables and on the parameters of the product. The complete
+density is
+
+$$
+\begin{aligned}
+h &= \left(\prod_{G\in\mathcal{G}}q_G\right)
+     \left(\prod_{i\in R}f_i\right),\\
+\mathcal{M} &= \int h\,d\mu_V,\\
+\text{PointProductPdf} &= \frac{h}{\mathcal{M}}.
+\end{aligned}
+$$
+
+The final integral is over all variates in $V$ on their applicable domain,
+with the parameters held fixed.
+When there are no conditional groups, $h=\prod_{i\in I}f_i$.
+
+A conditional group defines a locally normalized factor. It need not equal
+the conditional density of the final joint distribution: other factors may
+depend on the same variates and change that conditional density. This
+construction therefore does not in general imply a chain-rule
+factorization or an independent sampling procedure.
+
+For example, suppose the variates for a use are $x$, $y$, and $z$, and
+`P1`, `P2`, and `P3` have densities $p_1(x,y)$, $p_2(y,z)$, and $p_3(z)$.
+To construct a joint distribution from the conditional density of $x$
+given $y$ derived from `P1`, and a marginal over $(y,z)$ proportional to
+$p_2(y,z)p_3(z)$, use
 
 ```json id="7u6e8l"
 {
+  "name": "conditional_product",
   "type": "point_product_dist",
   "factors": ["P1", "P2", "P3"],
   "conditionals": [
@@ -147,40 +219,105 @@ may be represented as
 }
 ```
 
-Here, `on: ["y"]` means that $y$ is held fixed while $p_1(x,y)$ is normalized over $x$, giving
+Here, `on: ["y"]` means that $y$ is held fixed while $p_1(x,y)$ is
+normalized over $x$, giving
 
 $$
-p_1(x\mid y)
-=
-\frac{p_1(x,y)}
-     {\int dx\,p_1(x,y)}.
+\begin{aligned}
+Z_1(y) &= \int p_1(x,y)\,dx,\\
+q_1(x\mid y) &= \frac{p_1(x,y)}{Z_1(y)}.
+\end{aligned}
 $$
 
-The complete product is therefore
-
-$$
-p_1(x\mid y)p_2(y,z)p_3(z),
-$$
-
-which is subsequently normalized over $x$, $y$, and $z$. Since $p_1(x\mid y)$ is already normalized over $x$ for fixed $y$, this reduces to
+The product $q_1(x\mid y)p_2(y,z)p_3(z)$ is subsequently normalized over
+$x$, $y$, and $z$. On the product domain, since $q_1(x\mid y)$ integrates
+to one over $x$ for fixed $y$, this gives
 
 $$
 p(x,y,z)
-=
-p_1(x\mid y)\,
+=q_1(x\mid y)\,
 \frac{p_2(y,z)p_3(z)}
-     {\int\!\!\int dy\,dz\,p_2(y,z)p_3(z)}
-=
-p_1(x\mid y)\,p(y,z).
+     {\int\!\!\int p_2(y,z)p_3(z)\,dy\,dz}
+=q_1(x\mid y)\,p_{23}(y,z).
 $$
 
-Conditionality belongs to the point-product structure rather than to the referenced distribution, so the same distribution may be used conditionally in one point product and jointly in another.
+Declaring the conditional group changes the model: the density is
+proportional to $p_1(x,y)p_2(y,z)p_3(z)/Z_1(y)$, rather than to the
+unmodified product $p_1(x,y)p_2(y,z)p_3(z)$. These generally describe
+different joint distributions, since $Z_1(y)$ need not be constant.
 
 The following constraints apply:
 
+* The enclosing `factors` array [shall]{.smallcaps} be non-empty and contain unique references to existing distributions.
+
 * Each factor [shall]{.smallcaps} appear in at most one `conditionals` entry.
 * Every `conditionals` entry's `factors` [shall]{.smallcaps} be a non-empty subset of the enclosing point product's `factors`.
-* Every variable listed in `on` [shall]{.smallcaps} be a variate of at least one factor referenced by the same `conditionals` entry.
+* Every variable listed in `on` [shall]{.smallcaps} be a variable on which at least one factor referenced by the same `conditionals` entry depends, including dependencies through functions.
+
+
+For each shared variate, the factor densities [shall]{.smallcaps} use the
+same reference measure in the particular use. Implementations
+[shall not]{.smallcaps} implicitly convert between incompatible reference
+measures when forming the point product. This requirement concerns variates;
+a shared parameter does not require a reference measure for integration.
+
+Every conditional normalization integral $Z_G$ over a non-empty set of
+variates [shall]{.smallcaps} exist and be finite and strictly positive on
+the domain of conditioning variables and parameters for which the
+conditional factor is used. The complete product's normalization integral
+$\mathcal{M}$ [shall]{.smallcaps} likewise exist and be finite and strictly
+positive. A zero, infinite, or undefined normalization integral does not
+define a valid density for that use. There is no implicit exception for
+points or sets of measure zero. Where a conditional denominator vanishes,
+the model must restrict its applicable domain or explicitly supply a
+conditional density defined at those points. The convention $q_G=1$ for
+$U_G=\varnothing$ applies only to the empty-variate case and does not
+extend to vanishing denominators for non-empty integration sets.
+
+An implementation that cannot preserve the specified semantics
+[shall]{.smallcaps} report the requested operation as unsupported. It
+[shall not]{.smallcaps} silently ignore conditional declarations, substitute
+a different product construction, or discard extended terms. An invalid
+use [shall]{.smallcaps} be reported as such rather than evaluated using a
+replacement model. These requirements do not prevent tools from inspecting
+or preserving objects they cannot evaluate.
+
+Extended factors are permitted. Their event-count terms retain the same
+meaning as in a Cartesian product. When the factors satisfy the requirements
+of `product_dist`, replacing it with `point_product_dist` [shall]{.smallcaps}
+preserve both the event-density and event-count parts of the model.
+For extended factors, the conditional and global normalization of event
+densities described above applies to their shape components. Their
+associated event-count terms are retained separately; this normalization
+[shall not]{.smallcaps} discard or replace them. In particular, a conditional
+shape factor that becomes identically one does not remove its associated
+event-count term.
+
+The following additional constraints apply to extended factors:
+
+* Multiple extended factors [may]{.smallcaps} be used when their event-count terms describe distinct, conditionally independent count observations, given the model parameters.
+* An event-count observation [shall not]{.smallcaps} contribute more than one extended term through the factors of the product, including nested factors.
+* When several factors describe different measurements of the same events, their event densities [shall]{.smallcaps} be combined with a single extended term for the shared event count.
+* Implementations [shall not]{.smallcaps} silently remove, merge, or select between competing extended terms for the same event-count observation.
+
+For example, for measurements $x$ and $y$ on the same $N$ events, first
+construct their joint event density $p(x,y)$ and then extend that composite
+once using `rate_extended_dist` (see [Poisson point process](#dist:poisson-point-process)).
+The resulting likelihood contribution is
+
+$$
+\operatorname{Pois}(N\mid\nu)\prod_{j=1}^{N}p(x_j,y_j),
+$$
+
+with one count term for the shared sample. Separate, conditionally
+independent samples may each contribute their own count term, even when
+their expected counts depend on shared parameters.
+
+Whether two count terms describe the same observation is determined by
+their association with the counted events in the particular use. Equal
+numerical counts or shared rate parameters do not establish that they
+describe the same observation. Normalizing a product of repeated count
+terms does not resolve double-counting; it changes the count model.
 
 
 #### Efficiency product distribution

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -87,7 +87,7 @@ $$
 \begin{aligned} \ensuremath{\mathcal{M}}&= \int d\Omega \prod_i^n f_i(x_1, x_2, \dots) = \int\int\dots dx_1 dx_2 \dots \prod_i^n f_i(x_1, x_2, \dots) \end{aligned} 
 $$
 
-Here, $d\Omega$ denotes the product measure over all observables in the current analysis context.
+Here, $d\Omega$ denotes the product measure over all observables in the current analysis context (see Section [Analyses](#sec:analyses)).
 
 The normalization factor $\ensuremath{\mathcal{M}}$ denotes the
 denominator applied to the product distribution.  The optional

--- a/docs/chapters/2.1_distributions.md
+++ b/docs/chapters/2.1_distributions.md
@@ -5,6 +5,33 @@ bibliography: hs3.bib
 
 ## Distributions {#sec:distributions} 
 The top-level component `distributions` contains an array of distributions in struct format. Distributions [must]{.smallcaps} be normalized, thus, the letter $\ensuremath{\mathcal{M}}$ in the following descriptions will always relate to the normalization of the distribution. The value of $\ensuremath{\mathcal{M}}$ is conditional on the current domain. It [must]{.smallcaps} be chosen such that the integral of the distribution over the current domain equals one. The implementations might chose to perform this integral using analytical or numerical means. 
+
+Which variables are treated as variates is determined by the use of a
+distribution. For example, pairing a distribution with data in a likelihood
+identifies the variates through the associated data. A distribution used as
+a prior has as its variates the quantities to which the prior applies, even
+when those quantities are parameters of the likelihood. The same distribution
+may be used with different choices of variates. Normalization is performed
+over the variates for that use and their applicable domain, holding the
+remaining variables fixed. Evaluating a density at specified values does
+not itself change this choice of variates.
+
+Every use requiring normalization [shall]{.smallcaps} determine the variates
+and their applicable domain unambiguously. These may be established by the
+associated data or by the statistical operation using the distribution,
+including information supplied by its caller. This also applies to priors,
+auxiliary terms with implicit observations, and standalone operations.
+If the available information does not determine the variates and their
+domain, the implementation [shall]{.smallcaps} report the use as
+underspecified rather than assume a choice.
+
+For example, a Gaussian with `x: "reco"`, `mean: "truth"`, and a fixed
+`sigma` may be paired with data over `reco` or with data over `truth`.
+In the first use it is normalized over `reco`, holding `truth` fixed;
+in the second it is normalized over `truth`, holding `reco` fixed.
+The field names in the distribution do not impose a permanent assignment
+of these roles.
+
 Each distribution [must]{.smallcaps} have the components `type`, denoting the kind of distribution described, and a component `name`, which acts as a unique identifier of this distribution among all other named objects. Distributions in general have the following keys: 
 
 -   `name`: custom unique string ([required]{.smallcaps}), e.     g.&nbsp;`my_distribution_of_x` 

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -23,7 +23,7 @@ The top-level component `functions` describes an array of mathematical functions
 
 In the following the implemented functions are described in detail. 
 
-### Product 
+### Product {#sec:product-function} 
 A product of values or functions $a_i$. 
 
 

--- a/docs/chapters/2.7_analyses.md
+++ b/docs/chapters/2.7_analyses.md
@@ -29,3 +29,18 @@ All parameters of all distributions in the likelihood must either be listed unde
   ... 
 ]
 ``` 
+
+An analysis defines the notion of an **analysis context** in which a
+likelihood or distribution is to be interpreted and evaluated. In
+particular, it specifies the likelihood, the parameter domains,
+initial values, and (optionally) priors that are to be used for a
+particular statistical task. Together with the statistical objects
+referenced by the analysis (such as datasets associated with the
+referenced likelihood), this determines the role of each variable
+during evaluation. Variables constrained by the supplied dataset are
+interpreted as **observables**, while all remaining variables are
+treated as **parameters**. Since the same distribution may participate
+in different analyses, the distinction between observables and
+parameters is not an intrinsic property of a distribution itself, but
+is defined by the current analysis context in the sense established in
+this section.


### PR DESCRIPTION
This PR extends `product_dist` with an optional `normalization` field that allows the normalization of a product distribution to be specified explicitly.

By default, a product distribution is normalized globally over all observables. The new `normalization` field instead allows subsets of factors to be normalized independently over specified observables. The resulting normalization factor is therefore no longer required to be a constant; it may depend on observables that are not integrated within a particular normalization group.

This provides a natural and implementation-independent way to represent conditional probability densities without introducing a dedicated `conditional_dist` object. Instead, conditionality is expressed as a property of the normalization structure of the product rather than as an intrinsic property of the individual distributions. For example, a factorization such as

$$
p(x,y,z) = p(x \mid y), p(y,z), p(z)
$$

can be represented as a product of ordinary distributions together with a normalization group that normalizes the first factor over `x`.

The proposal also defines the necessary constraints on normalization groups to ensure that the resulting normalization is well-defined and unambiguous.
