### PR TITLE
Update the function and distribution catalogs following issue #99

### DIFF
--- a/docs/chapters/2.1.1_fundamental_distributions.md
+++ b/docs/chapters/2.1.1_fundamental_distributions.md
@@ -185,6 +185,43 @@ $$
 -   `sigma`: value or name of the parameter encoding the standard     deviation $\sigma$. 
 
 
+#### Gaussian resolution model
+
+The Gaussian resolution model represents Gaussian smearing in the convolution variable $x$:
+
+$$
+\begin{aligned}
+\text{GaussResolutionModel}(x,\mu,\sigma) =
+\frac{1}{\sigma\sqrt{2\pi}}\exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right).
+\end{aligned}
+$$
+
+It is a distribution that can be used as a resolution model for analytical convolutions.
+
+-   `name`: custom unique string
+-   `type`: `gauss_resolution_model` (current draft spelling; `gauss_model_function` is the legacy HS${}^3$ v0.2.9 key)
+-   `x`: name of the convolution variable $x$
+-   `mean`: value or name of the mean parameter $\mu$
+-   `sigma`: value or name of the width parameter $\sigma$
+
+
+#### Delta resolution model
+
+The delta resolution model corresponds to perfect resolution in the convolution variable:
+
+$$
+\begin{aligned}
+\text{DeltaResolutionModel}(x) = \delta(x).
+\end{aligned}
+$$
+
+When used in an analytical convolution, it returns the unconvolved basis function.
+
+-   `name`: custom unique string
+-   `type`: `delta_resolution_model` (current draft spelling; `truth_model_function` is the legacy HS${}^3$ v0.2.9 key)
+-   `x`: name of the convolution variable $x$
+
+
 #### Generalized Normal distribution
 
 The generalized normal distribution is defined as
@@ -225,6 +262,24 @@ $$
 -   `x`: name of the variable $x$ 
 -   `mu`: value or name of the parameter used as $\mu$ 
 -   `sigma`: value or name of the parameter $\sigma$ describing the     shape 
+
+
+#### Landau distribution
+
+The Landau distribution describes fluctuations in the energy loss of a charged particle traversing a thin layer of material. In terms of the conventional Landau density $L$, it is
+
+$$
+\begin{aligned}
+\text{LandauPdf}(x,\mu,\sigma) =
+\frac{1}{\ensuremath{\mathcal{M}}}\,L(x;\mu,\sigma).
+\end{aligned}
+$$
+
+-   `name`: custom unique string
+-   `type`: `landau_dist`
+-   `x`: name of the variable $x$
+-   `mean`: value or name of the location parameter $\mu$
+-   `sigma`: value or name of the scale parameter $\sigma$
 
 #### Poisson distribution {#dist:poisson label="dist:poisson"} 
 

--- a/docs/chapters/2.1.1_fundamental_distributions.md
+++ b/docs/chapters/2.1.1_fundamental_distributions.md
@@ -226,6 +226,24 @@ $$
 -   `mu`: value or name of the parameter used as $\mu$ 
 -   `sigma`: value or name of the parameter $\sigma$ describing the     shape 
 
+
+#### Landau distribution
+
+The Landau distribution describes fluctuations in the energy loss of a charged particle traversing a thin layer of material. In terms of the conventional Landau density $L$, it is
+
+$$
+\begin{aligned}
+\text{LandauPdf}(x,\mu,\sigma) =
+\frac{1}{\ensuremath{\mathcal{M}}}\,L(x;\mu,\sigma).
+\end{aligned}
+$$
+
+-   `name`: custom unique string
+-   `type`: `landau_dist`
+-   `x`: name of the variable $x$
+-   `mean`: value or name of the location parameter $\mu$
+-   `sigma`: value or name of the scale parameter $\sigma$
+
 #### Poisson distribution {#dist:poisson label="dist:poisson"} 
 
 The Poisson distribution of the variable $x$ is defined as 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -37,13 +37,13 @@ $$
 $$
 
 
-#### Mixture model
+#### Mixture resolution model
 
-The mixture model is a weighted sum of resolution models or model PDFs:
+The mixture resolution model is a weighted sum of resolution models or model PDFs:
 
 $$
 \begin{aligned}
-\text{MixtureModel}(x) = \sum_{i=1}^{n} c_i\,m_i(x).
+\text{MixtureResolutionModel}(x) = \sum_{i=1}^{n} c_i\,m_i(x).
 \end{aligned}
 $$
 
@@ -58,10 +58,33 @@ $$
 If all coefficients are given, their sum is used as the expected number of events in extended use cases.
 
 -   `name`: custom unique string
--   `type`: `mixture_model`
+-   `type`: `mixture_resolution_model`
 -   `summands`: array of names referencing model distributions
 -   `coefficients`: array of names of coefficients $c_i$ or numbers
 -   `extended`: boolean denoting whether this is an extended model
+
+
+#### FFT convolution distribution
+
+The FFT convolution distribution represents the one-dimensional convolution of two distributions:
+
+$$
+\begin{aligned}
+\text{FFTConvolutionPdf}(x) =
+\frac{1}{\ensuremath{\mathcal{M}}}
+\int f_1(t)\,f_2(x-t)\,dt.
+\end{aligned}
+$$
+
+The convolution is evaluated numerically using a fast Fourier transform. The discrete Fourier transform treats the convolution variable as cyclic, so implementations and model authors must account for wrap-around effects at the domain boundaries, for example by using a suitable buffer region.
+
+-   `name`: custom unique string
+-   `type`: `fft_convolution_dist`
+-   `pdf1`: name of the first input distribution $f_1$
+-   `pdf2`: name of the second input distribution $f_2$
+-   `conv_var`: name of the one-dimensional convolution variable $x$
+-   `conv_func`: name of the function mapped onto `conv_var` ([optional]{.smallcaps})
+-   `ipOrder`: interpolation order used to evaluate the cached convolution
 
 
 #### Product distribution {#sec:product-distribution label="sec:product-distribution"} 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -64,6 +64,29 @@ If all coefficients are given, their sum is used as the expected number of event
 -   `extended`: boolean denoting whether this is an extended model
 
 
+#### FFT convolution distribution
+
+The FFT convolution distribution represents the one-dimensional convolution of two distributions:
+
+$$
+\begin{aligned}
+\text{FFTConvolutionPdf}(x) =
+\frac{1}{\ensuremath{\mathcal{M}}}
+\int f_1(t)\,f_2(x-t)\,dt.
+\end{aligned}
+$$
+
+The convolution is evaluated numerically using a fast Fourier transform. The discrete Fourier transform treats the convolution variable as cyclic, so implementations and model authors must account for wrap-around effects at the domain boundaries, for example by using a suitable buffer region.
+
+-   `name`: custom unique string
+-   `type`: `fft_convolution_dist`
+-   `pdf1`: name of the first input distribution $f_1$
+-   `pdf2`: name of the second input distribution $f_2$
+-   `conv_var`: name of the one-dimensional convolution variable $x$
+-   `conv_func`: name of the function mapped onto `conv_var` ([optional]{.smallcaps})
+-   `ipOrder`: interpolation order used to evaluate the cached convolution
+
+
 #### Product distribution {#sec:product-distribution label="sec:product-distribution"} 
 
 The product of independent distributions $f_i$ is defined as 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -64,29 +64,6 @@ If all coefficients are given, their sum is used as the expected number of event
 -   `extended`: boolean denoting whether this is an extended model
 
 
-#### FFT convolution distribution
-
-The FFT convolution distribution represents the one-dimensional convolution of two distributions:
-
-$$
-\begin{aligned}
-\text{FFTConvolutionPdf}(x) =
-\frac{1}{\ensuremath{\mathcal{M}}}
-\int f_1(t)\,f_2(x-t)\,dt.
-\end{aligned}
-$$
-
-The convolution is evaluated numerically using a fast Fourier transform. The discrete Fourier transform treats the convolution variable as cyclic, so implementations and model authors must account for wrap-around effects at the domain boundaries, for example by using a suitable buffer region.
-
--   `name`: custom unique string
--   `type`: `fft_convolution_dist`
--   `pdf1`: name of the first input distribution $f_1$
--   `pdf2`: name of the second input distribution $f_2$
--   `conv_var`: name of the one-dimensional convolution variable $x$
--   `conv_func`: name of the function mapped onto `conv_var` ([optional]{.smallcaps})
--   `ipOrder`: interpolation order used to evaluate the cached convolution
-
-
 #### Product distribution {#sec:product-distribution label="sec:product-distribution"} 
 
 The product of independent distributions $f_i$ is defined as 

--- a/docs/chapters/2.1_distributions.md
+++ b/docs/chapters/2.1_distributions.md
@@ -44,5 +44,6 @@ An example of a distribution `gauss1` that has no free parameters and might be u
 
 Distributions can be treated either as `extended` or as non-`extended` [@barlow-extended-ml]. Some distributions are always extended, others can never be extended, yet others can be used in extended and non-extended scenarios and have a switch selecting between the two. An non-extended distribution is always normalized to the unity. An extended distribution, on the other hand, can yield values larger than unity, where the yield is interpreted as the number of predicted events. That is to say, the distribution is augmented by a factor that is a Poisson constraint term for the total number of events. 
 In the following, all distributions supported in HS${}^3$ v0.2.9 are listed in detail. Future versions will expand upon this list. 
+Entries explicitly identified as current draft spellings document ongoing post-v0.2.9 work and have not yet been assigned to a new HS${}^3$ version.
 
 In Cartesian products of distributions, their variate records are concatenated.

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -84,38 +84,24 @@ The order is intended for first, second, or third derivatives, and `eps` control
 -   `eps`: step size used for the numerical derivative
 -   `normalization`: array of names defining the normalization set ([optional]{.smallcaps})
 
-### Gaussian Resolution Model
-The Gaussian resolution model represents a Gaussian smearing model in the convolution variable $x$:
+### Integral Function
+
+The integral function represents the integral of a function $f$ over one or more variables:
 
 $$
 \begin{aligned}
-\text{GaussModel}(x,\mu,\sigma) =
-\frac{1}{\sigma\sqrt{2\pi}}\exp\left(-\frac{(x-\mu)^2}{2\sigma^2}\right).
+\text{Integral}(f,\vec{x}) = \int f(\vec{x})\,d\vec{x}.
 \end{aligned}
 $$
 
-It can be used as a resolution model for analytical convolutions.
+If `domain` is present, the integral uses the named domain for the integration variables. If `normalization` is present, the integrand is evaluated with that normalization set.
 
 -   `name`: custom unique string
--   `type`: `gauss_model_function`
--   `x`: name of the convolution variable $x$
--   `mean`: value or name of the mean parameter $\mu$
--   `sigma`: value or name of the width parameter $\sigma$
-
-### Truth Resolution Model
-The truth resolution model corresponds to perfect resolution, represented by a delta function in the convolution variable:
-
-$$
-\begin{aligned}
-\text{TruthModel}(x) = \delta(x).
-\end{aligned}
-$$
-
-When used in an analytical convolution, it returns the unconvolved basis function.
-
--   `name`: custom unique string
--   `type`: `truth_model_function`
--   `x`: name of the convolution variable $x$
+-   `type`: `integral`
+-   `integrand`: name of the function $f$ to integrate
+-   `variables`: array of names of the integration variables $\vec{x}$
+-   `domain`: name of the integration domain ([optional]{.smallcaps})
+-   `normalization`: array of names defining the normalization set ([optional]{.smallcaps})
 
 ### Generic Function 
 *Note: Users should prefer the specific functions defined in this standard over generic functions where possible, as implementations of these will typically be more optimized. Generic functions should only be used if no equivalent specific distribution is defined.* 
@@ -123,5 +109,5 @@ A generic function is defined by an expression. The expression must be a valid H
 [Generic Expressions](#sec:generic_expression){reference-type="ref" reference="sec:generic_expression"}). 
 
 -   `name`: custom unique string 
--   `type`: `generic_function` 
+-   `type`: `generic` (current draft spelling; `generic_function` is the legacy HS${}^3$ v0.2.9 key)
 -   `expression`: a string with a generic mathematical expression.     Simple mathematical syntax common to programming languages should be     used here, such as `x-2*y+z`. For any non-elementary operations, the     behavior is undefined. 

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -117,11 +117,30 @@ When used in an analytical convolution, it returns the unconvolved basis functio
 -   `type`: `truth_model_function`
 -   `x`: name of the convolution variable $x$
 
+### Integral Function
+
+The integral function represents the integral of a function $f$ over one or more variables:
+
+$$
+\begin{aligned}
+\text{Integral}(f,\vec{x}) = \int f(\vec{x})\,d\vec{x}.
+\end{aligned}
+$$
+
+If `domain` is present, the integral uses the named domain for the integration variables. If `normalization` is present, the integrand is evaluated with that normalization set.
+
+-   `name`: custom unique string
+-   `type`: `integral`
+-   `integrand`: name of the function $f$ to integrate
+-   `variables`: array of names of the integration variables $\vec{x}$
+-   `domain`: name of the integration domain ([optional]{.smallcaps})
+-   `normalization`: array of names defining the normalization set ([optional]{.smallcaps})
+
 ### Generic Function 
 *Note: Users should prefer the specific functions defined in this standard over generic functions where possible, as implementations of these will typically be more optimized. Generic functions should only be used if no equivalent specific distribution is defined.* 
 A generic function is defined by an expression. The expression must be a valid HS<sup>3</sup>-expression string (see Section 
 [Generic Expressions](#sec:generic_expression){reference-type="ref" reference="sec:generic_expression"}). 
 
 -   `name`: custom unique string 
--   `type`: `generic_function` 
+-   `type`: `generic` (current draft spelling; `generic_function` is the legacy HS${}^3$ v0.2.9 key)
 -   `expression`: a string with a generic mathematical expression.     Simple mathematical syntax common to programming languages should be     used here, such as `x-2*y+z`. For any non-elementary operations, the     behavior is undefined. 

--- a/docs/chapters/3.1_generic_expressions.md
+++ b/docs/chapters/3.1_generic_expressions.md
@@ -20,6 +20,8 @@ The implementations that support generic expression [must]{.smallcaps} support:
     -   `log(x)`: Natural logarithm of `x` 
     -   `sqrt(x)`: The square root of `x` 
     -   `abs(x)`: The absolute value of `x` 
+    -   `floor(x)`: The greatest integer less than or equal to `x`
+    -   `ceil(x)`: The smallest integer greater than or equal to `x`
     -   `pow(x, y)`: `x` raised to the power of `y` 
     -   `min(x, y)`: minimum of `x` and `y` 
     -   `max(x, y)`: maximum of `x` and `y` 
@@ -29,6 +31,7 @@ The implementations that support generic expression [must]{.smallcaps} support:
     -   `asin(x)`: The inverse sin of `x` 
     -   `acos(x)`: The inverse cosine of `x` 
     -   `atan(x)`: The inverse tangent of `x` 
+    -   `erf(x)`: The standard error function of `x`
 	
 Symbols not defined here refer to variables in the HS${}^3$ model. 
 The operator precedence and associativity is according to the common conventions. 


### PR DESCRIPTION
## Summary

This PR updates the HS3 function and distribution catalogs following the audit in #99. It documents functionality that is already supported by the implementations and test fixtures, records the current draft type keys, and moves resolution models into the distribution catalog where they belong.

## Catalog changes

### Fundamental distributions

- Added `landau_dist` with `x`, `mean`, and `sigma`.

### Composite distributions

- Retained its `summands`, `coefficients`, and `extended` fields, including the existing coefficient and extended-model semantics.

### Functions

- Added `integral` with `integrand`, `variables`, optional `domain`, and optional `normalization`.
- Changed the current draft generic-function type key to `generic` and retained `generic_function` as the historical v0.2.9 spelling.

### Generic expressions

- Added the standard error function `erf(x)`.
- Added `floor(x)` and `ceil(x)` after verifying export/import round-trip support.

## Type-key compatibility

The legacy names are historical annotations, not additional canonical spellings.

## Issue #99 audit

| Item | Audit result | Documentation in this PR |
|---|---|---|
| `polynomial` function | Resolved; implementation, fixtures, and catalog agree | No change required |
| `integral` function | Supported but absent from the catalog | Added |
| `derivative` function | Resolved | No change required |
| `chebychev_dist` | Resolved | No change required |
| `landau_dist` | Supported but absent from the catalog | Added |
| `decay_dist` | Resolved | No change required |
| `efficiency_product_pdf_dist` | Implemented and documented; semantics remain under discussion in #104 | Left unchanged |
| Numeric polynomial coefficients | Fixed in `rf203` and `rf313`; `rf311` still contains four numeric strings | Still unresolved; no fixture change in this documentation PR |
| `erf` expression | Supported but absent from the generic-expression catalog | Added |
| Data-axis `value` | Resolved in the current fixtures | No change required |
| Parameter-point `min`/`max` | Resolved; ranges are serialized in domains | No change required |

Relates to #99.
