### PR TITLE
Introduce authoring guidelines for new HS3 primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ different statistical procedures and results used in High Energy Physics
 versions are defined with specifications and semantics that are
 acknowledged by a committee.
 
-View the current draft of the HS³ standard here: https://hep-statistics-serialization-standard.github.io/
+View the current draft of the HS³ standard [here](https://hep-statistics-serialization-standard.github.io/).
 
 Corresponding implementations to check the
 validity of files are also provided, at a _best effort_ basis.
@@ -66,8 +66,6 @@ The focus of this project is not on the long-term storage of large data,
 which may be needed for an actual implementation, but rather to define a
 common serialization format.
 
-TODO: more description
-
 # Standard versions
 
 Until 1.x, the standard is considered unstable and may introduce
@@ -84,7 +82,11 @@ In order to submit ideas, proposals and examples, you can either start a
 discussion using issues or add the document(s), if you have some, in the
 proposals (draft or pending) folder and create a PR to discussion them.
 
-If you are interest to become part of the core committee, please open an
+Please make sure to read the [authorship
+guidelines](https://github.com/hep-statistics-serialization-standard/hep-statistics-serialization-standard/blob/master/docs/chapters/3.2_authoring_primitives.md)
+before you contribute or review content.
+
+If you are interested to become part of the core committee, please open an
 issue. Anyone is allowed to join.
 
 ## Emoji-Reactions to Issues, PRs, Discussions and Comments

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -1,5 +1,5 @@
 ---
-bibliography: ./hs3.bib
+bibliography: hs3.bib
 ---
 
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -14,7 +14,7 @@ Primitive specifications define the mathematical semantics of new HS³ primitive
 Primitive specifications should be understandable to three audiences simultaneously:
 
 - **Software implementers**, who should be able to implement import, export, and evaluation directly from the specification.
-- **Domain experts**, who should be recognize how concepts from existing software correspond to the HS³ representation.
+- **Domain experts**, who should recognize how concepts from existing software correspond to the HS³ representation.
 - **Statisticians**, who should be able to infer the mathematical properties of the primitive directly from its specification and serialized representation.
 
 The mathematical definition is normative. Implementation-specific terminology may be used where it improves understanding, but should complement rather than replace the mathematical semantics.

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -46,7 +46,7 @@ Every primitive specification shall define:
 
 Primitive specifications should define the normative semantics of a primitive independently of any particular implementation. Whenever practical, this should be done by specifying the mathematical object represented by the primitive. Where no sufficiently precise mathematical characterization exists, or where the algorithm itself defines the abstraction, a normative algorithmic specification may be used instead.
 
-The amount of explanatory material should be proportional to the complexity of the primitive. Closed-form mathematical primitives generally require little more than their definition and serialization, whereas implementation-backed primitives shall include whatever additional explanation is necessary for independent implementations. Informative mappings to existing software are encouraged but never replace the mathematical definition.
+The amount of explanatory material should be proportional to the complexity of the primitive. Simple primitives may require little more than their mathematical definition and serialization. More complex primitives should include whatever additional explanation is necessary to enable independent conforming implementations. Informative mappings to existing software are encouraged but never replace the normative definition.
 
 ### Serialization
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -3,7 +3,7 @@ bibliography: ./hs3.bib
 ---
 
 
-## Authoring Requirements for HS³ Primitive Specifications
+## Authoring Requirements for HS³ Primitive Specifications {#sec:primitive_authoring_requirements} 
 
 This appendix is **normative**.
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -88,6 +88,6 @@ Normative text defines behaviour. Informative text may provide motivation, examp
 
 As a practical guideline, contributors should continuously ask:
 
-> Could an independent implementation of this primitive be written correctly from this specification alone, together with the documentation of any explicitly referenced external libraries?
+> Could an independent, faithful implementation of this primitive be written without ambiguity from this specification alone, together with the documentation of any explicitly referenced external libraries?
 
 If the answer is no, the specification is likely missing semantic or algorithmic information.

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -3,18 +3,18 @@ bibliography: hs3.bib
 ---
 
 
-## Authoring Requirements for HS³ Primitive Specifications {#sec:primitive_authoring_requirements} 
+## Authoring Requirements for HS$^3$ Primitive Specifications {#sec:primitive_authoring_requirements} 
 
 This appendix is **normative**.
 
-Primitive specifications define the mathematical semantics of new HS³ primitives. Their purpose is to enable independent implementations to interpret serialized models consistently and without ambiguity.
+Primitive specifications define the mathematical semantics of new HS$^3$ primitives. Their purpose is to enable independent implementations to interpret serialized models consistently and without ambiguity.
 
 ### Intended audience
 
 Primitive specifications [should]{.smallcaps} be understandable to three audiences simultaneously:
 
 - **Software implementers**, who should be able to implement import, export, and evaluation directly from the specification.
-- **Domain experts**, who should recognize how concepts from existing software correspond to the HS³ representation.
+- **Domain experts**, who should recognize how concepts from existing software correspond to the HS$^3$ representation.
 - **Statisticians**, who should be able to infer the mathematical properties of the primitive directly from its specification and serialized representation.
 
 The mathematical definition is normative. Implementation-specific terminology may be used where it improves understanding, but [should]{.smallcaps} complement rather than replace the mathematical semantics.
@@ -25,15 +25,15 @@ A primitive specifies **what** a model computes, not **how** a particular implem
 
 Specifications shall therefore define primitives in mathematical terms whenever practical. Implementation-specific concepts may be included only where they are necessary to faithfully represent existing software.
 
-A primitive that introduces functionality which cannot already be represented using existing HS³ primitives will generally be appropriate, provided its semantics are well defined.
+A primitive that introduces functionality which cannot already be represented using existing HS$^3$ primitives will generally be appropriate, provided its semantics are well defined.
 
 A primitive that only specializes an existing abstraction [should]{.smallcaps} provide clear additional value, such as a substantially more compact representation of a common use case, access to significantly more efficient or numerically robust evaluation strategies, or improved interoperability through the explicit representation of a widely recognized abstraction.
 
-### Relationship to the HS³ language
+### Relationship to the HS$^3$ language
 
-Primitive specifications extend the vocabulary of HS³ but do not redefine the language itself.
+Primitive specifications extend the vocabulary of HS$^3$ but do not redefine the language itself.
 
-Primitive specifications may introduce new functions, distributions, or regular members of any other existing top-level HS³ category (see Section @sec:toplevel). They shall not introduce new language constructs. In particular, a primitive shall not change its semantic role based on configuration or context, create or transform other serialized objects, or introduce control-flow, parser directives, or other metaprogramming facilities. Such proposals constitute extensions of the HS³ language and require separate specification and review.
+Primitive specifications may introduce new functions, distributions, or regular members of any other existing top-level HS$^3$ category (see Section @sec:toplevel). They shall not introduce new language constructs. In particular, a primitive shall not change its semantic role based on configuration or context, create or transform other serialized objects, or introduce control-flow, parser directives, or other metaprogramming facilities. Such proposals constitute extensions of the HS$^3$ language and require separate specification and review.
 
 ### Required specification
 
@@ -68,7 +68,7 @@ Information that has no effect on mathematical evaluation shall be stored in `mi
 
 Where a primitive represents functionality already established in an existing framework or scientific domain, its semantics [should]{.smallcaps} remain recognizable to domain experts while preserving implementation-independent mathematical meaning.
 
-Primitive specifications [should]{.smallcaps} minimize the conceptual distance between established domain abstractions and their HS³ representation. Generalization is appropriate where it improves interoperability or removes accidental implementation details. It [should]{.smallcaps} be avoided where it obscures established abstractions or complicates import, export, or implementation without providing corresponding semantic benefit.
+Primitive specifications [should]{.smallcaps} minimize the conceptual distance between established domain abstractions and their HS$^3$ representation. Generalization is appropriate where it improves interoperability or removes accidental implementation details. It [should]{.smallcaps} be avoided where it obscures established abstractions or complicates import, export, or implementation without providing corresponding semantic benefit.
 
 ### Alternative implementations
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -33,9 +33,7 @@ A primitive that only specializes an existing abstraction should provide clear a
 
 Primitive specifications extend the vocabulary of HS³ but do not redefine the language itself.
 
-A primitive shall belong to an existing HS³ semantic category and inherit the evaluation and composition semantics of that category.
-
-Primitive specifications shall not introduce changes to the HS³ language implicitly. Changes such as new top-level categories, evaluation rules, composition mechanisms, or modifications to existing constructs require separate review. Likewise, fields whose values alter the semantic category, evaluation contract, normalization behaviour, or permitted composition of an object generally indicate either multiple distinct primitives or an evolution of the HS³ language, rather than configuration of a single primitive. Such changes in general require extensive community review before they can be accepted.
+Primitive specifications may introduce new functions, distributions, or regular members of any other existing top-level HS³ category (see Section @sec:toplevel). They shall not introduce new language constructs. In particular, a primitive shall not change its semantic role based on configuration or context, create or transform other serialized objects, or introduce control-flow, parser directives, or other metaprogramming facilities. Such proposals constitute extensions of the HS³ language and require separate specification and review.
 
 ### Required specification
 
@@ -46,7 +44,7 @@ Every primitive specification shall define:
 - any normative default values;
 - sufficient examples to remove ambiguity.
 
-Whenever practical, primitives should be defined by closed-form mathematical expressions. Algorithmic definitions should be used only where no compact mathematical formulation exists.
+Primitive specifications should define the normative semantics of a primitive independently of any particular implementation. Whenever practical, this should be done by specifying the mathematical object represented by the primitive. Where no sufficiently precise mathematical characterization exists, or where the algorithm itself defines the abstraction, a normative algorithmic specification may be used instead.
 
 The amount of explanatory material should be proportional to the complexity of the primitive. Closed-form mathematical primitives generally require little more than their definition and serialization, whereas implementation-backed primitives shall include whatever additional explanation is necessary for independent implementations. Informative mappings to existing software are encouraged but never replace the mathematical definition.
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -11,13 +11,13 @@ Primitive specifications define the mathematical semantics of new HS³ primitive
 
 ### Intended audience
 
-Primitive specifications should be understandable to three audiences simultaneously:
+Primitive specifications [should]{.smallcaps} be understandable to three audiences simultaneously:
 
 - **Software implementers**, who should be able to implement import, export, and evaluation directly from the specification.
 - **Domain experts**, who should recognize how concepts from existing software correspond to the HS³ representation.
 - **Statisticians**, who should be able to infer the mathematical properties of the primitive directly from its specification and serialized representation.
 
-The mathematical definition is normative. Implementation-specific terminology may be used where it improves understanding, but should complement rather than replace the mathematical semantics.
+The mathematical definition is normative. Implementation-specific terminology may be used where it improves understanding, but [should]{.smallcaps} complement rather than replace the mathematical semantics.
 
 ### Design principles
 
@@ -27,7 +27,7 @@ Specifications shall therefore define primitives in mathematical terms whenever 
 
 A primitive that introduces functionality which cannot already be represented using existing HS³ primitives will generally be appropriate, provided its semantics are well defined.
 
-A primitive that only specializes an existing abstraction should provide clear additional value, such as a substantially more compact representation of a common use case, access to significantly more efficient or numerically robust evaluation strategies, or improved interoperability through the explicit representation of a widely recognized abstraction.
+A primitive that only specializes an existing abstraction [should]{.smallcaps} provide clear additional value, such as a substantially more compact representation of a common use case, access to significantly more efficient or numerically robust evaluation strategies, or improved interoperability through the explicit representation of a widely recognized abstraction.
 
 ### Relationship to the HS³ language
 
@@ -44,17 +44,17 @@ Every primitive specification shall define:
 - any normative default values;
 - sufficient examples to remove ambiguity.
 
-Primitive specifications should define the normative semantics of a primitive independently of any particular implementation. Whenever practical, this should be done by specifying the mathematical object represented by the primitive. Where no sufficiently precise mathematical characterization exists, or where the algorithm itself defines the abstraction, a normative algorithmic specification may be used instead.
+Primitive specifications [should]{.smallcaps} define the normative semantics of a primitive independently of any particular implementation. Whenever practical, this [should]{.smallcaps} be done by specifying the mathematical object represented by the primitive. Where no sufficiently precise mathematical characterization exists, or where the algorithm itself defines the abstraction, a normative algorithmic specification may be used instead.
 
-The amount of explanatory material should be proportional to the complexity of the primitive. Simple primitives may require little more than their mathematical definition and serialization. More complex primitives should include whatever additional explanation is necessary to enable independent conforming implementations. Informative mappings to existing software are encouraged but never replace the normative definition.
+The amount of explanatory material [should]{.smallcaps} be proportional to the complexity of the primitive. Simple primitives may require little more than their mathematical definition and serialization. More complex primitives [should]{.smallcaps} include whatever additional explanation is necessary to enable independent conforming implementations. Informative mappings to existing software are encouraged but never replace the normative definition.
 
 ### Serialization
 
 Every serialized field shall have a well-defined mathematical meaning.
 
-Serialized objects should expose mathematical structure wherever practical. Mathematical concepts such as coefficients, tensors, domains, or observables should be preferred over implementation-specific concepts such as object handles or memory layouts.
+Serialized objects [should]{.smallcaps} expose mathematical structure wherever practical. Mathematical concepts such as coefficients, tensors, domains, or observables [should]{.smallcaps} be preferred over implementation-specific concepts such as object handles or memory layouts.
 
-Implementation-specific state may be serialized where necessary, but should remain self-contained, inspectable, schema-validatable, and editable whenever practical. References to external binary objects should be avoided unless no practical alternative exists.
+Implementation-specific state may be serialized where necessary, but [should]{.smallcaps} remain self-contained, inspectable, schema-validatable, and editable whenever practical. References to external binary objects [should]{.smallcaps} be avoided unless no practical alternative exists.
 
 ### Defaults and miscellaneous information
 
@@ -66,15 +66,15 @@ Information that has no effect on mathematical evaluation shall be stored in `mi
 
 ### Existing implementations
 
-Where a primitive represents functionality already established in an existing framework or scientific domain, its semantics should remain recognizable to domain experts while preserving implementation-independent mathematical meaning.
+Where a primitive represents functionality already established in an existing framework or scientific domain, its semantics [should]{.smallcaps} remain recognizable to domain experts while preserving implementation-independent mathematical meaning.
 
-Primitive specifications should minimize the conceptual distance between established domain abstractions and their HS³ representation. Generalization is appropriate where it improves interoperability or removes accidental implementation details. It should be avoided where it obscures established abstractions or complicates import, export, or implementation without providing corresponding semantic benefit.
+Primitive specifications [should]{.smallcaps} minimize the conceptual distance between established domain abstractions and their HS³ representation. Generalization is appropriate where it improves interoperability or removes accidental implementation details. It [should]{.smallcaps} be avoided where it obscures established abstractions or complicates import, export, or implementation without providing corresponding semantic benefit.
 
 ### Alternative implementations
 
 An enum-like field may select between alternative methods when those methods operate on the same serialized state and the meaning of all other fields remains unchanged. The selected method may alter how that state is interpreted or evaluated, but shall not determine which disjoint set of fields is applicable.
 
-If different enum values require substantially different configuration data, parameterizations, or validity conditions, they should generally be represented as separate primitives rather than as variants of a single primitive.
+If different enum values require substantially different configuration data, parameterizations, or validity conditions, they [should]{.smallcaps} generally be represented as separate primitives rather than as variants of a single primitive.
 
 Implementations need to support only a subset of the methods defined by a primitive specification. An implementation that does not support the requested method shall not silently substitute another method. It shall either reject the object or explicitly report the use of a semantically valid fallback.
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -2,441 +2,94 @@
 bibliography: ./hs3.bib
 ---
 
+
 ## Authoring Requirements for HS³ Primitive Specifications
 
 This appendix is **normative**.
 
-It defines the minimum requirements that every new primitive shall satisfy before
-being considered part of the HS³ specification.
+Primitive specifications define the mathematical semantics of new HS³ primitives. Their purpose is to enable independent implementations to interpret serialized models consistently and without ambiguity.
 
-The purpose of these requirements is not to prescribe a particular writing style,
-but to ensure that independent implementations interpret every primitive
-consistently and without ambiguity.
+## Intended audience
 
-### Design philosophy
+Primitive specifications should be understandable to three audiences simultaneously:
 
-HS³ is a mathematical interchange format.
+- **Software implementers**, who should be able to implement import, export, and evaluation directly from the specification.
+- **Domain experts**, who should be recognize how concepts from existing software correspond to the HS³ representation.
+- **Statisticians**, who should be able to infer the mathematical properties of the primitive directly from its specification and serialized representation.
 
-Each primitive specifies the mathematical semantics of a model component,
-independent of any particular software framework.
+The mathematical definition is normative. Implementation-specific terminology may be used where it improves understanding, but should complement rather than replace the mathematical semantics.
 
-A primitive shall therefore describe **what** a model computes, rather than
-**how** an existing implementation computes it.
+### Design principles
 
-Whenever possible, mathematical definitions should take precedence over
-implementation-specific concepts.
+A primitive specifies **what** a model computes, not **how** a particular implementation computes it.
 
-For example,
+Specifications shall therefore define primitives in mathematical terms whenever practical. Implementation-specific concepts may be included only where they are necessary to faithfully represent existing software.
 
-- algebraic expressions should be preferred over references to software classes,
-- mathematical functions should be preferred over framework-specific APIs,
-- immutable mathematical state should be preferred over opaque implementation
-  objects.
-
-Implementation-specific concepts may be included whenever they are necessary to
-bridge an existing software package whose semantics cannot yet be expressed in a
-more general mathematical form.
+A primitive should introduce only the semantic concept that is genuinely new. Prediction models, statistical interpretations, normalization conventions, and composition rules should remain separate whenever they can already be expressed using existing HS³ primitives.
 
 ### Relationship to the HS³ language
 
-Primitive specifications extend the vocabulary of the HS³ language. They do not
-redefine the language itself.
+Primitive specifications extend the vocabulary of HS³ but do not redefine the language itself.
 
-Every new primitive shall fall unambiguously into one of the top-level semantic
-categories already defined by HS³ and shall use the evaluation and composition
-semantics associated with that category.
+A primitive shall belong to an existing HS³ semantic category and inherit the evaluation and composition semantics of that category.
 
-Assigning a primitive to an existing category is not sufficient if fields or
-modes of the primitive alter the codomain, normalization contract, statistical
-interpretation, or permitted composition of objects in that category. Such
-behaviour constitutes either a new semantic category or several distinct
-primitives and shall not be introduced implicitly through an enum-like field.
+Primitive specifications shall not introduce changes to the HS³ language implicitly. Changes such as new top-level categories, evaluation rules, composition mechanisms, or modifications to existing constructs require separate review. Likewise, fields whose values alter the semantic category, evaluation contract, normalization behaviour, or permitted composition of an object generally indicate either multiple distinct primitives or an evolution of the HS³ language, rather than configuration of a single primitive. Such changes in general require extensive community review before they can be accepted.
 
-A proposal that introduces
+### Required specification
 
-- a new top-level semantic category,
-- new evaluation semantics,
-- new composition mechanisms,
-- or changes to the interpretation of existing HS³ constructs
+Every primitive specification shall define:
 
-is not considered a new primitive, but an evolution of the HS³ language itself.
-Such changes are not prohibited, but require separate community discussion and
-review. The proposal should provide a well-justified use case, explain why the
-required functionality cannot be expressed within the existing language, and
-assess its impact on existing serialized models, schemas, and implementations.
+- its mathematical semantics, or an equivalent algorithmic definition;
+- the meaning of every serialized field, including the relationship between serialized objects and the mathematical quantities they represent;
+- any normative default values;
+- sufficient examples to remove ambiguity.
 
-Contributors should therefore avoid introducing new language-level concepts as
-part of a primitive specification. Where such concepts are genuinely required,
-they should be proposed explicitly as changes to the standard rather than being
-embedded implicitly in the definition of a single primitive.
+Whenever practical, primitives should be defined by closed-form mathematical expressions. Algorithmic definitions should be used only where no compact mathematical formulation exists.
 
-### Composition before extension
-
-Before introducing a new primitive, contributors should determine whether the
-desired behaviour can be expressed by composing existing HS³ primitives.
-
-In particular, a parameter-dependent prediction and the statistical object that
-uses that prediction should normally be represented separately whenever HS³
-already provides the required statistical construction. For example, a binned
-yield prediction may be composed with an existing Poisson point-process
-primitive rather than being embedded directly in a new distribution primitive.
-
-A primitive should therefore introduce only the semantic concept that is not
-already represented elsewhere in HS³. It should not simultaneously introduce a
-new prediction, normalization convention, statistical interpretation, and
-composition rule when those concepts can be factorized.
-
-A common implementation dependency does not imply that all uses of that
-dependency should be represented by one primitive. Where the same underlying
-calculation is exposed through different top-level statistical abstractions,
-contributors should prefer
-
-- composition with existing primitives; or
-- separate primitives in the corresponding categories.
-
-If separate primitives share identical mathematical behaviour, the common
-semantics may be defined once in supplementary material and referenced by each
-primitive. The category-specific primitives should then differ only where the
-semantics of their respective top-level categories require it.
-
-### Intended audience
-
-Primitive specifications are intended to be readable by several different
-communities simultaneously.
-
-A specification should therefore enable all of the following.
-
-#### Software implementers
-
-A software engineer familiar with a statistical inference framework, but not
-necessarily with the scientific domain that motivated the primitive, should be
-able to implement
-
-- an importer,
-- an exporter,
-- and an evaluator
-
-using only
-
-- this specification,
-- the documentation of any explicitly referenced external library,
-- and documentation of the target inference framework.
-
-No additional domain-specific knowledge should be required.
-
-#### Domain experts
-
-A scientist familiar with a particular implementation should be able to identify
-how the concepts used by that implementation correspond to the concepts defined
-by the primitive.
-
-This enables reliable exporter implementations and facilitates validation of
-existing software against the HS³ representation.
-
-Implementation-specific terminology may therefore be discussed where it improves
-understanding, provided that such terminology does not replace the mathematical
-definition.
-
-#### Statisticians
-
-A reader with a statistical background should be able to determine the
-mathematical properties of the primitive directly from the specification and
-from the serialized representation.
-
-The JSON representation should expose mathematical structure wherever practical,
-rather than hiding it inside opaque implementation objects.
-
-### Required level of specification
-
-The amount of documentation required for a primitive depends on its complexity.
-
-#### Simple mathematical primitives
-
-Primitives whose behaviour is completely defined by a closed-form mathematical
-expression generally require only
-
-- a mathematical definition,
-- parameter definitions,
-- domain and codomain,
-- serialization,
-- and one illustrative example.
-
-Typical examples include
-
-- Gaussian distributions,
-- Crystal Ball functions,
-- polynomial expressions,
-- spline interpolation.
-
-#### Composite or implementation-backed primitives
-
-Primitives whose semantics cannot be completely captured by a compact
-mathematical expression require additional explanatory material.
-
-Examples include
-
-- wrappers around external software,
-- tensor contractions,
-- numerical algorithms,
-- procedural model construction,
-- plugin interfaces.
-
-Such primitives should include sufficient semantic detail that an independent
-implementation can reproduce the intended behaviour without consulting the
-original authors.
-
-The amount of explanatory text should therefore be proportional to the
-complexity of the primitive.
-
-### Structure of primitive specifications
-
-The HS³ specification intentionally does not prescribe a rigid template for the
-documentation of every primitive.
-
-Simple mathematical primitives are most naturally specified by a concise
-mathematical definition together with a description of their JSON components,
-whereas more sophisticated primitives may require additional explanatory text,
-examples, algorithms, or mappings to existing software.
-
-Contributors should therefore follow the style used throughout this document,
-rather than adhering to a fixed chapter structure.
-
-Regardless of presentation, every primitive specification shall provide
-sufficient information to unambiguously define the mathematical semantics of the
-primitive.
-
-Depending on the complexity of the primitive, this information typically
-includes
-
-- a mathematical definition of the primitive, or, where no compact closed-form
-  expression exists, an equivalent algorithmic definition;
-- the meaning of every JSON component introduced by the primitive;
-- the relationship between serialized objects and the mathematical quantities
-  they represent;
-- any constraints or invariants that valid serialized objects must satisfy;
-- sufficient examples to illustrate the intended use of the primitive.
-
-Whenever a primitive describes functionality already implemented by existing
-software packages, contributors are encouraged to document how the concepts used
-by those packages correspond to the concepts defined by the primitive.
-Such mappings are informative and should complement, but never replace, the
-mathematical definition.
-
-For primitives whose semantics are completely captured by a compact mathematical
-expression, additional explanatory material is usually unnecessary.
-
-Conversely, primitives whose behaviour depends on procedural algorithms,
-external software packages, or complex mathematical constructions should include
-whatever additional explanation is required to enable independent
-implementations.
-
-### Mathematical semantics
-
-Every primitive shall define its mathematical behaviour independently of any
-particular software framework.
-
-Whenever possible, the mathematical definition shall uniquely determine the
-output of the primitive.
-
-For primitives whose behaviour cannot be expressed completely by a compact
-closed-form expression, the specification shall instead define the evaluation
-algorithm in sufficient detail that equivalent implementations can be produced.
+The amount of explanatory material should be proportional to the complexity of the primitive. Closed-form mathematical primitives generally require little more than their definition and serialization, whereas implementation-backed primitives shall include whatever additional explanation is necessary for independent implementations. Informative mappings to existing software are encouraged but never replace the mathematical definition.
 
 ### Serialization
 
-Every serialized field shall have a clearly defined mathematical meaning.
+Every serialized field shall have a well-defined mathematical meaning.
 
-Keys should correspond to mathematical concepts whenever practical.
+Serialized objects should expose mathematical structure wherever practical. Mathematical concepts such as coefficients, tensors, domains, or observables should be preferred over implementation-specific concepts such as object handles or memory layouts.
 
-For example,
+Implementation-specific state may be serialized where necessary, but should remain self-contained, inspectable, schema-validatable, and editable whenever practical. References to external binary objects should be avoided unless no practical alternative exists.
 
-- coefficients,
-- tensors,
-- coordinate vectors,
-- domains,
-- observables,
+### Defaults and miscellaneous information
 
-are preferable to implementation-specific concepts such as
+Evaluation shall be completely determined by the serialized object together with any normative defaults defined by the primitive.
 
-- payloads,
-- handles,
-- object identifiers,
-- memory layouts.
+Optional fields that affect evaluation shall have unique specification-defined default values. Such defaults shall not depend on implementations, external libraries, software versions, or backend-specific conventions.
 
-Implementation-specific state may be serialized when necessary to preserve the
-semantics of an existing implementation.
+Information that has no effect on mathematical evaluation shall be stored in `misc`. Conforming evaluators shall produce equivalent results regardless of the contents of `misc`, although implementations may use it for diagnostics, visualization, optimization, or internal representation.
 
-Whenever possible, such state should remain
+### Existing implementations
 
-- self-contained,
-- inspectable,
-- schema-validatable,
-- and editable.
+Where a primitive represents functionality already established in an existing framework or scientific domain, its semantics should remain recognizable to domain experts while preserving implementation-independent mathematical meaning.
 
-References to external binary objects should be avoided unless no practical
-alternative exists.
+Primitive specifications should minimize the conceptual distance between established domain abstractions and their HS³ representation. Generalization is appropriate where it improves interoperability or removes accidental implementation details. It should be avoided where it obscures established abstractions or complicates import, export, or implementation without providing corresponding semantic benefit.
 
-### Mandatory, optional, and miscellaneous information
+### Alternative implementations
 
-The evaluation semantics of a primitive shall be completely determined by the
-serialized object together with any default values defined normatively by the
-primitive.
+An enum-like field may select between alternative implementations only if the alternatives represent the same mathematical abstraction, operate on substantially the same serialized state, and differ only in evaluation strategy.
 
-A field may be optional and still affect evaluation only when the primitive
-defines a unique normative default value. Omitting the field shall then be
-semantically equivalent to serializing that default value explicitly.
+Alternatives requiring different parameterizations, serialized structures, mathematical assumptions, or validity conditions shall be represented by separate primitives.
 
-Defaults that affect evaluation shall be defined by the HS³ specification
-itself. They shall not depend on
+The meaning of every alternative shall be defined normatively. Unsupported alternatives shall either produce an explicit error or an explicitly reported substitution; silent substitution is not permitted. 
 
-- the importing framework;
-- an external library or software version;
-- the backend selected by an implementation;
-- or an implementation-specific convention.
-
-Information that has no normative effect on evaluation shall be stored in
-`misc`.
-
-Removing information from `misc` shall not change the result produced by any
-conforming evaluator. Such information may nevertheless affect
-
-- the implementation strategy or in-memory representation;
-- diagnostics and provenance;
-- visualization, names, titles, or plotting hints;
-- suggested minimizer or optimizer settings;
-- caching, acceleration, or other performance choices.
-
-An implementation may use information from `misc` to choose a more efficient or
-more natural internal representation, but that representation shall remain
-mathematically equivalent to evaluation without the `misc` information.
-
-### Mapping to existing implementations
-
-If a primitive represents functionality that already exists in one or more
-software packages, the specification should describe how concepts from those
-packages correspond to the mathematical concepts defined by the primitive.
-
-Such mappings are informative.
-
-They do not replace the mathematical definition.
-
-### Faithfulness to existing domain abstractions
-
-Many HS³ primitives are introduced to represent functionality that already
-exists within one or more software packages or scientific communities.
-
-The purpose of such a primitive is to provide a mathematically and statistically
-precise, implementation-independent representation of that functionality, not to
-redesign or generalize the underlying abstraction unnecessarily.
-
-Within the bounds of mathematical and statistical correctness, the semantics of
-a primitive should follow established domain implementations where practical.
-Concepts familiar to practitioners of the source domain should remain
-recognizable in the specification so that domain experts can identify how the
-serialized keys and structures map onto the objects they already use.
-
-The terminology of a source implementation may differ substantially from the
-mathematical or statistical language used by HS³. In such cases, the normative
-keys should retain precise implementation-independent meanings, while
-informative text should state explicitly how those meanings correspond to the
-terminology and concepts of the source domain.
-
-Contributors should strive to minimize the conceptual distance between
-
-- the source implementation,
-- the HS³ representation,
-- and target implementations.
-
-Generalization is appropriate when it is required to express the underlying
-semantics, improve interoperability, or remove accidental implementation details.
-It should be avoided when it obscures abstractions that are common to the source
-domain, makes importers or exporters unnecessarily indirect, or prevents an
-elegant and efficient implementation in the intended target frameworks.
-
-### Alternative implementations and related primitives
-
-A mathematical operation may admit several nominally or approximately
-equivalent implementations. Primitive authors shall distinguish between
-alternative implementations of the same abstraction and distinct mathematical
-approaches.
-
-An enum-like field may select between alternative implementations when all of
-the following conditions hold:
-
-- the alternatives serve the same mathematical role;
-- they operate on overwhelmingly identical serialized information;
-- they expose substantially the same parameters and configuration;
-- and selecting an alternative does not materially change the structure of the
-  primitive.
-
-Typical examples include interpolation algorithms that operate on the same
-support points, coefficients, domains, and boundary conditions.
-
-The meaning of every enum value shall be defined normatively. An implementation
-that does not support a requested alternative may either
-
-- reject the object with an explicit unsupported-feature error; or
-- reroute evaluation to another supported alternative, provided that the
-  substitution is permitted by the primitive and is reported with an explicit
-  warning.
-
-Silent substitution is not permitted.
-
-An enum-like field should not be used when the alternatives require
-substantially different serialized state, parameterizations, configuration
-structures, mathematical assumptions, or validity conditions. In such cases,
-each approach should be represented by a separate primitive.
-
-Related primitives may share common semantics, schema fragments, documentation,
-or supplementary definitions. Their common parts should be factorized where
-this avoids duplication, while each primitive shall still define unambiguously
-the information and behaviour specific to its approach.
-
-Where two families of primitives represent alternative formulations of the same
-prediction, it should generally be possible to define tooling that transforms
-one representation into the other, at least within a documented domain of
-validity. Such a transformation may be exact or approximate, but its limitations
-shall be stated.
-
-If no reasonably direct converter can be defined, this is strong evidence that
-the primitives represent distinct concepts and should be documented and
-reviewed independently rather than presented as modes of one abstraction.
+The ability to define a reasonably direct transformation between two alternatives is often a good indication that they represent different implementations of the same abstraction rather than distinct primitives.
 
 ### Conformance
 
-A primitive specification is considered sufficiently complete if independent
-implementations can reproduce equivalent mathematical behaviour.
+A primitive specification is complete if independent implementations can reproduce equivalent mathematical behaviour from the specification alone, together with the documentation of any explicitly referenced external libraries.
 
-For simple primitives, the mathematical definition alone may be sufficient.
+Normative text defines behaviour. Informative text may provide motivation, examples, implementation guidance, historical context, or mappings to existing software, but does not contribute to the formal definition of the primitive.
 
-For more complex primitives, additional examples, reference calculations,
-evaluation algorithms, or implementation guidance may be necessary.
+### Editorial Guideline
 
-The specification should contain enough information that ambiguity in the
-resulting implementation is minimized.
+As a practical guideline, contributors should continuously ask:
 
-### Normative versus informative text
+> Could an independent implementation of this primitive be written correctly from this specification alone, together with the documentation of any explicitly referenced external libraries?
 
-Specifications should clearly distinguish between
-
-- normative text, which defines behaviour,
-- and informative text, which provides motivation, examples, implementation
-  advice, historical context, or mappings to existing software.
-
-Only normative text contributes to the formal definition of the primitive.
-
-### Editorial guideline
-
-As a practical guideline, contributors should continuously ask the following
-question while preparing a new primitive.
-
-> Could an independent implementation of this primitive be written correctly
-> from this specification alone, together with the documentation of any
-> explicitly referenced external libraries?
-
-If the answer is no, the specification is likely missing mathematical,
-algorithmic, or semantic information.
-
-Conversely, if additional implementation-specific details merely duplicate what
-already follows uniquely from the mathematical definition, those details should
-normally be omitted.
+If the answer is no, the specification is likely missing semantic or algorithmic information.

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -2,12 +2,12 @@
 bibliography: ./hs3.bib
 ---
 
-## Authoring Requirements for HS3 Primitive Specifications
+## Authoring Requirements for HS³ Primitive Specifications
 
 This appendix is **normative**.
 
 It defines the minimum requirements that every new primitive shall satisfy before
-being considered part of the HS3 specification.
+being considered part of the HS³ specification.
 
 The purpose of these requirements is not to prescribe a particular writing style,
 but to ensure that independent implementations interpret every primitive
@@ -15,7 +15,7 @@ consistently and without ambiguity.
 
 ### Design philosophy
 
-HS3 is a mathematical interchange format.
+HS³ is a mathematical interchange format.
 
 Each primitive specifies the mathematical semantics of a model component,
 independent of any particular software framework.
@@ -69,7 +69,7 @@ how the concepts used by that implementation correspond to the concepts defined
 by the primitive.
 
 This enables reliable exporter implementations and facilitates validation of
-existing software against the HS3 representation.
+existing software against the HS³ representation.
 
 Implementation-specific terminology may therefore be discussed where it improves
 understanding, provided that such terminology does not replace the mathematical
@@ -128,7 +128,7 @@ complexity of the primitive.
 
 ### Structure of primitive specifications
 
-The HS3 specification intentionally does not prescribe a rigid template for the
+The HS³ specification intentionally does not prescribe a rigid template for the
 documentation of every primitive.
 
 Simple mathematical primitives are most naturally specified by a concise

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -1,0 +1,264 @@
+---
+bibliography: ./hs3.bib
+---
+
+## Authoring Requirements for HS3 Primitive Specifications
+
+This appendix is **normative**.
+
+It defines the minimum requirements that every new primitive shall satisfy before
+being considered part of the HS3 specification.
+
+The purpose of these requirements is not to prescribe a particular writing style,
+but to ensure that independent implementations interpret every primitive
+consistently and without ambiguity.
+
+### Design philosophy
+
+HS3 is a mathematical interchange format.
+
+Each primitive specifies the mathematical semantics of a model component,
+independent of any particular software framework.
+
+A primitive shall therefore describe **what** a model computes, rather than
+**how** an existing implementation computes it.
+
+Whenever possible, mathematical definitions should take precedence over
+implementation-specific concepts.
+
+For example,
+
+- algebraic expressions should be preferred over references to software classes,
+- mathematical functions should be preferred over framework-specific APIs,
+- immutable mathematical state should be preferred over opaque implementation
+  objects.
+
+Implementation-specific concepts may be included whenever they are necessary to
+bridge an existing software package whose semantics cannot yet be expressed in a
+more general mathematical form.
+
+### Intended audience
+
+Primitive specifications are intended to be readable by several different
+communities simultaneously.
+
+A specification should therefore enable all of the following.
+
+#### Software implementers
+
+A software engineer familiar with a statistical inference framework, but not
+necessarily with the scientific domain that motivated the primitive, should be
+able to implement
+
+- an importer,
+- an exporter,
+- and an evaluator
+
+using only
+
+- this specification,
+- the documentation of any explicitly referenced external library,
+- and documentation of the target inference framework.
+
+No additional domain-specific knowledge should be required.
+
+#### Domain experts
+
+A scientist familiar with a particular implementation should be able to identify
+how the concepts used by that implementation correspond to the concepts defined
+by the primitive.
+
+This enables reliable exporter implementations and facilitates validation of
+existing software against the HS3 representation.
+
+Implementation-specific terminology may therefore be discussed where it improves
+understanding, provided that such terminology does not replace the mathematical
+definition.
+
+#### Statisticians
+
+A reader with a statistical background should be able to determine the
+mathematical properties of the primitive directly from the specification and
+from the serialized representation.
+
+The JSON representation should expose mathematical structure wherever practical,
+rather than hiding it inside opaque implementation objects.
+
+### Required level of specification
+
+The amount of documentation required for a primitive depends on its complexity.
+
+#### Simple mathematical primitives
+
+Primitives whose behaviour is completely defined by a closed-form mathematical
+expression generally require only
+
+- a mathematical definition,
+- parameter definitions,
+- domain and codomain,
+- serialization,
+- and one illustrative example.
+
+Typical examples include
+
+- Gaussian distributions,
+- Crystal Ball functions,
+- polynomial expressions,
+- spline interpolation.
+
+#### Composite or implementation-backed primitives
+
+Primitives whose semantics cannot be completely captured by a compact
+mathematical expression require additional explanatory material.
+
+Examples include
+
+- wrappers around external software,
+- tensor contractions,
+- numerical algorithms,
+- procedural model construction,
+- plugin interfaces.
+
+Such primitives should include sufficient semantic detail that an independent
+implementation can reproduce the intended behaviour without consulting the
+original authors.
+
+The amount of explanatory text should therefore be proportional to the
+complexity of the primitive.
+
+### Structure of primitive specifications
+
+The HS3 specification intentionally does not prescribe a rigid template for the
+documentation of every primitive.
+
+Simple mathematical primitives are most naturally specified by a concise
+mathematical definition together with a description of their JSON components,
+whereas more sophisticated primitives may require additional explanatory text,
+examples, algorithms, or mappings to existing software.
+
+Contributors should therefore follow the style used throughout this document,
+rather than adhering to a fixed chapter structure.
+
+Regardless of presentation, every primitive specification shall provide
+sufficient information to unambiguously define the mathematical semantics of the
+primitive.
+
+Depending on the complexity of the primitive, this information typically
+includes
+
+- a mathematical definition of the primitive, or, where no compact closed-form
+  expression exists, an equivalent algorithmic definition;
+- the meaning of every JSON component introduced by the primitive;
+- the relationship between serialized objects and the mathematical quantities
+  they represent;
+- any constraints or invariants that valid serialized objects must satisfy;
+- sufficient examples to illustrate the intended use of the primitive.
+
+Whenever a primitive describes functionality already implemented by existing
+software packages, contributors are encouraged to document how the concepts used
+by those packages correspond to the concepts defined by the primitive.
+Such mappings are informative and should complement, but never replace, the
+mathematical definition.
+
+For primitives whose semantics are completely captured by a compact mathematical
+expression, additional explanatory material is usually unnecessary.
+
+Conversely, primitives whose behaviour depends on procedural algorithms,
+external software packages, or complex mathematical constructions should include
+whatever additional explanation is required to enable independent
+implementations.
+
+### Mathematical semantics
+
+Every primitive shall define its mathematical behaviour independently of any
+particular software framework.
+
+Whenever possible, the mathematical definition shall uniquely determine the
+output of the primitive.
+
+For primitives whose behaviour cannot be expressed completely by a compact
+closed-form expression, the specification shall instead define the evaluation
+algorithm in sufficient detail that equivalent implementations can be produced.
+
+### Serialization
+
+Every serialized field shall have a clearly defined mathematical meaning.
+
+Keys should correspond to mathematical concepts whenever practical.
+
+For example,
+
+- coefficients,
+- tensors,
+- coordinate vectors,
+- domains,
+- observables,
+
+are preferable to implementation-specific concepts such as
+
+- payloads,
+- handles,
+- object identifiers,
+- memory layouts.
+
+Implementation-specific state may be serialized when necessary to preserve the
+semantics of an existing implementation.
+
+Whenever possible, such state should remain
+
+- self-contained,
+- inspectable,
+- schema-validatable,
+- and editable.
+
+References to external binary objects should be avoided unless no practical
+alternative exists.
+
+### Mapping to existing implementations
+
+If a primitive represents functionality that already exists in one or more
+software packages, the specification should describe how concepts from those
+packages correspond to the mathematical concepts defined by the primitive.
+
+Such mappings are informative.
+
+They do not replace the mathematical definition.
+
+### Conformance
+
+A primitive specification is considered sufficiently complete if independent
+implementations can reproduce equivalent mathematical behaviour.
+
+For simple primitives, the mathematical definition alone may be sufficient.
+
+For more complex primitives, additional examples, reference calculations,
+evaluation algorithms, or implementation guidance may be necessary.
+
+The specification should contain enough information that ambiguity in the
+resulting implementation is minimized.
+
+### Normative versus informative text
+
+Specifications should clearly distinguish between
+
+- normative text, which defines behaviour,
+- and informative text, which provides motivation, examples, implementation
+  advice, historical context, or mappings to existing software.
+
+Only normative text contributes to the formal definition of the primitive.
+
+### Editorial guideline
+
+As a practical guideline, contributors should continuously ask the following
+question while preparing a new primitive.
+
+> Could an independent implementation of this primitive be written correctly
+> from this specification alone, together with the documentation of any
+> explicitly referenced external libraries?
+
+If the answer is no, the specification is likely missing mathematical,
+algorithmic, or semantic information.
+
+Conversely, if additional implementation-specific details merely duplicate what
+already follows uniquely from the mathematical definition, those details should
+normally be omitted.

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -76,7 +76,7 @@ An enum-like field may select between alternative methods when those methods ope
 
 If different enum values require substantially different configuration data, parameterizations, or validity conditions, they should generally be represented as separate primitives rather than as variants of a single primitive.
 
-Implementations need support only a subset of the methods defined by a primitive specification. An implementation that does not support the requested method shall not silently substitute another method. It shall either reject the object or explicitly report the use of a semantically valid fallback.
+Implementations need to support only a subset of the methods defined by a primitive specification. An implementation that does not support the requested method shall not silently substitute another method. It shall either reject the object or explicitly report the use of a semantically valid fallback.
 
 ### Conformance
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -72,13 +72,11 @@ Primitive specifications should minimize the conceptual distance between establi
 
 ### Alternative implementations
 
-An enum-like field may select between alternative implementations only if the alternatives represent the same mathematical abstraction, operate on substantially the same serialized state, and differ only in evaluation strategy.
+An enum-like field may select between alternative methods when those methods operate on the same serialized state and the meaning of all other fields remains unchanged. The selected method may alter how that state is interpreted or evaluated, but shall not determine which disjoint set of fields is applicable.
 
-Alternatives requiring different parameterizations, serialized structures, mathematical assumptions, or validity conditions shall be represented by separate primitives.
+If different enum values require substantially different configuration data, parameterizations, or validity conditions, they should generally be represented as separate primitives rather than as variants of a single primitive.
 
-The meaning of every alternative shall be defined normatively. Unsupported alternatives shall either produce an explicit error or an explicitly reported substitution; silent substitution is not permitted. 
-
-The ability to define a reasonably direct transformation between two alternatives is often a good indication that they represent different implementations of the same abstraction rather than distinct primitives.
+Implementations need support only a subset of the methods defined by a primitive specification. An implementation that does not support the requested method shall not silently substitute another method. It shall either reject the object or explicitly report the use of a semantically valid fallback.
 
 ### Conformance
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -5,8 +5,6 @@ bibliography: hs3.bib
 
 ## Authoring Requirements for HS$^3$ Primitive Specifications {#sec:primitive_authoring_requirements} 
 
-This appendix is **normative**.
-
 Primitive specifications define the mathematical semantics of new HS$^3$ primitives. Their purpose is to enable independent implementations to interpret serialized models consistently and without ambiguity.
 
 ### Intended audience

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -25,7 +25,9 @@ A primitive specifies **what** a model computes, not **how** a particular implem
 
 Specifications shall therefore define primitives in mathematical terms whenever practical. Implementation-specific concepts may be included only where they are necessary to faithfully represent existing software.
 
-A primitive should introduce only the semantic concept that is genuinely new. Prediction models, statistical interpretations, normalization conventions, and composition rules should remain separate whenever they can already be expressed using existing HS³ primitives.
+A primitive that introduces functionality which cannot already be represented using existing HS³ primitives will generally be appropriate, provided its semantics are well defined.
+
+A primitive that only specializes an existing abstraction should provide clear additional value, such as a substantially more compact representation of a common use case, access to significantly more efficient or numerically robust evaluation strategies, or improved interoperability through the explicit representation of a widely recognized abstraction.
 
 ### Relationship to the HS³ language
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -46,6 +46,12 @@ Every new primitive shall fall unambiguously into one of the top-level semantic
 categories already defined by HS³ and shall use the evaluation and composition
 semantics associated with that category.
 
+Assigning a primitive to an existing category is not sufficient if fields or
+modes of the primitive alter the codomain, normalization contract, statistical
+interpretation, or permitted composition of objects in that category. Such
+behaviour constitutes either a new semantic category or several distinct
+primitives and shall not be introduced implicitly through an enum-like field.
+
 A proposal that introduces
 
 - a new top-level semantic category,
@@ -63,6 +69,35 @@ Contributors should therefore avoid introducing new language-level concepts as
 part of a primitive specification. Where such concepts are genuinely required,
 they should be proposed explicitly as changes to the standard rather than being
 embedded implicitly in the definition of a single primitive.
+
+### Composition before extension
+
+Before introducing a new primitive, contributors should determine whether the
+desired behaviour can be expressed by composing existing HS³ primitives.
+
+In particular, a parameter-dependent prediction and the statistical object that
+uses that prediction should normally be represented separately whenever HS³
+already provides the required statistical construction. For example, a binned
+yield prediction may be composed with an existing Poisson point-process
+primitive rather than being embedded directly in a new distribution primitive.
+
+A primitive should therefore introduce only the semantic concept that is not
+already represented elsewhere in HS³. It should not simultaneously introduce a
+new prediction, normalization convention, statistical interpretation, and
+composition rule when those concepts can be factorized.
+
+A common implementation dependency does not imply that all uses of that
+dependency should be represented by one primitive. Where the same underlying
+calculation is exposed through different top-level statistical abstractions,
+contributors should prefer
+
+- composition with existing primitives; or
+- separate primitives in the corresponding categories.
+
+If separate primitives share identical mathematical behaviour, the common
+semantics may be defined once in supplementary material and referenced by each
+primitive. The category-specific primitives should then differ only where the
+semantics of their respective top-level categories require it.
 
 ### Intended audience
 
@@ -241,6 +276,40 @@ Whenever possible, such state should remain
 References to external binary objects should be avoided unless no practical
 alternative exists.
 
+### Mandatory, optional, and miscellaneous information
+
+The evaluation semantics of a primitive shall be completely determined by the
+serialized object together with any default values defined normatively by the
+primitive.
+
+A field may be optional and still affect evaluation only when the primitive
+defines a unique normative default value. Omitting the field shall then be
+semantically equivalent to serializing that default value explicitly.
+
+Defaults that affect evaluation shall be defined by the HS³ specification
+itself. They shall not depend on
+
+- the importing framework;
+- an external library or software version;
+- the backend selected by an implementation;
+- or an implementation-specific convention.
+
+Information that has no normative effect on evaluation shall be stored in
+`misc`.
+
+Removing information from `misc` shall not change the result produced by any
+conforming evaluator. Such information may nevertheless affect
+
+- the implementation strategy or in-memory representation;
+- diagnostics and provenance;
+- visualization, names, titles, or plotting hints;
+- suggested minimizer or optimizer settings;
+- caching, acceleration, or other performance choices.
+
+An implementation may use information from `misc` to choose a more efficient or
+more natural internal representation, but that representation shall remain
+mathematically equivalent to evaluation without the `misc` information.
+
 ### Mapping to existing implementations
 
 If a primitive represents functionality that already exists in one or more
@@ -283,6 +352,55 @@ semantics, improve interoperability, or remove accidental implementation details
 It should be avoided when it obscures abstractions that are common to the source
 domain, makes importers or exporters unnecessarily indirect, or prevents an
 elegant and efficient implementation in the intended target frameworks.
+
+### Alternative implementations and related primitives
+
+A mathematical operation may admit several nominally or approximately
+equivalent implementations. Primitive authors shall distinguish between
+alternative implementations of the same abstraction and distinct mathematical
+approaches.
+
+An enum-like field may select between alternative implementations when all of
+the following conditions hold:
+
+- the alternatives serve the same mathematical role;
+- they operate on overwhelmingly identical serialized information;
+- they expose substantially the same parameters and configuration;
+- and selecting an alternative does not materially change the structure of the
+  primitive.
+
+Typical examples include interpolation algorithms that operate on the same
+support points, coefficients, domains, and boundary conditions.
+
+The meaning of every enum value shall be defined normatively. An implementation
+that does not support a requested alternative may either
+
+- reject the object with an explicit unsupported-feature error; or
+- reroute evaluation to another supported alternative, provided that the
+  substitution is permitted by the primitive and is reported with an explicit
+  warning.
+
+Silent substitution is not permitted.
+
+An enum-like field should not be used when the alternatives require
+substantially different serialized state, parameterizations, configuration
+structures, mathematical assumptions, or validity conditions. In such cases,
+each approach should be represented by a separate primitive.
+
+Related primitives may share common semantics, schema fragments, documentation,
+or supplementary definitions. Their common parts should be factorized where
+this avoids duplication, while each primitive shall still define unambiguously
+the information and behaviour specific to its approach.
+
+Where two families of primitives represent alternative formulations of the same
+prediction, it should generally be possible to define tooling that transforms
+one representation into the other, at least within a documented domain of
+validity. Such a transformation may be exact or approximate, but its limitations
+shall be stated.
+
+If no reasonably direct converter can be defined, this is strong evidence that
+the primitives represent distinct concepts and should be documented and
+reviewed independently rather than presented as modes of one abstraction.
 
 ### Conformance
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -9,7 +9,7 @@ This appendix is **normative**.
 
 Primitive specifications define the mathematical semantics of new HS³ primitives. Their purpose is to enable independent implementations to interpret serialized models consistently and without ambiguity.
 
-## Intended audience
+### Intended audience
 
 Primitive specifications should be understandable to three audiences simultaneously:
 

--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -37,6 +37,33 @@ Implementation-specific concepts may be included whenever they are necessary to
 bridge an existing software package whose semantics cannot yet be expressed in a
 more general mathematical form.
 
+### Relationship to the HS³ language
+
+Primitive specifications extend the vocabulary of the HS³ language. They do not
+redefine the language itself.
+
+Every new primitive shall fall unambiguously into one of the top-level semantic
+categories already defined by HS³ and shall use the evaluation and composition
+semantics associated with that category.
+
+A proposal that introduces
+
+- a new top-level semantic category,
+- new evaluation semantics,
+- new composition mechanisms,
+- or changes to the interpretation of existing HS³ constructs
+
+is not considered a new primitive, but an evolution of the HS³ language itself.
+Such changes are not prohibited, but require separate community discussion and
+review. The proposal should provide a well-justified use case, explain why the
+required functionality cannot be expressed within the existing language, and
+assess its impact on existing serialized models, schemas, and implementations.
+
+Contributors should therefore avoid introducing new language-level concepts as
+part of a primitive specification. Where such concepts are genuinely required,
+they should be proposed explicitly as changes to the standard rather than being
+embedded implicitly in the definition of a single primitive.
+
 ### Intended audience
 
 Primitive specifications are intended to be readable by several different
@@ -223,6 +250,39 @@ packages correspond to the mathematical concepts defined by the primitive.
 Such mappings are informative.
 
 They do not replace the mathematical definition.
+
+### Faithfulness to existing domain abstractions
+
+Many HS³ primitives are introduced to represent functionality that already
+exists within one or more software packages or scientific communities.
+
+The purpose of such a primitive is to provide a mathematically and statistically
+precise, implementation-independent representation of that functionality, not to
+redesign or generalize the underlying abstraction unnecessarily.
+
+Within the bounds of mathematical and statistical correctness, the semantics of
+a primitive should follow established domain implementations where practical.
+Concepts familiar to practitioners of the source domain should remain
+recognizable in the specification so that domain experts can identify how the
+serialized keys and structures map onto the objects they already use.
+
+The terminology of a source implementation may differ substantially from the
+mathematical or statistical language used by HS³. In such cases, the normative
+keys should retain precise implementation-independent meanings, while
+informative text should state explicitly how those meanings correspond to the
+terminology and concepts of the source domain.
+
+Contributors should strive to minimize the conceptual distance between
+
+- the source implementation,
+- the HS³ representation,
+- and target implementations.
+
+Generalization is appropriate when it is required to express the underlying
+semantics, improve interoperability, or remove accidental implementation details.
+It should be avoided when it obscures abstractions that are common to the source
+domain, makes importers or exporters unnecessarily indirect, or prevents an
+elegant and efficient implementation in the intended target frameworks.
 
 ### Conformance
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,5 +56,7 @@ title: HS3
 
 {% include-markdown "chapters/3.1_generic_expressions.md" %}
 
+{% include-markdown "chapters/3.2_authoring_primitives.md" %}
+
 # References 
 \bibliography

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
   - Appendix:
       - Supplementary: chapters/3_supplementary.md
       - Generic Expressions: chapters/3.1_generic_expressions.md
+      - Authoring Primitives: chapters/3.2_authoring_primitives.md
   - PDF version: files/hs3.pdf
     
 


### PR DESCRIPTION
## Motivation

As HS³ continues to grow, an increasing number of new primitive types are being proposed. While the existing specification defines the *syntax* and *semantics* of the primitives themselves, it currently provides little guidance on **how new primitives should be specified**.

This PR introduces a new appendix that establishes authoring guidelines for future primitive specifications.

The goal is not to prescribe a rigid document template, but rather to define a quality standard for new additions to the specification.

## Main ideas

The appendix emphasizes that HS³ is fundamentally a mathematical interchange format. Primitive specifications should therefore describe the mathematical semantics of a model component independently of any particular software framework whenever possible.

At the same time, the specification should remain useful for several different audiences:

* software engineers implementing importers, exporters or evaluators in new inference frameworks,
* domain experts mapping existing software concepts onto HS3,
* statisticians inspecting serialized models to understand their mathematical structure.

The amount of documentation required for a primitive should be proportional to its complexity. A simple closed-form function may require little more than its mathematical definition and JSON syntax, whereas more sophisticated primitives—such as wrappers around external software packages or algorithmic model representations—may require substantially more explanation in order to permit independent implementations.

## Guiding principle

The appendix proposes a practical criterion for evaluating new primitive specifications:

> A primitive specification should contain sufficient mathematical, algorithmic and semantic information that independent implementations can reproduce equivalent behaviour without requiring additional clarification from the primitive authors.

This criterion intentionally focuses on interoperability rather than implementation details.

## Scope

This PR is purely editorial.

It introduces guidance for future contributors but does **not** modify the syntax or semantics of any existing HS3 primitive.

The appendix is intended to improve consistency across future extensions while preserving the concise style already used throughout the specification for simple mathematical primitives.
