### PR TITLE
Introduce indexed distributions, function definitions and indexed data sets.

### DIFF
--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -7,7 +7,7 @@ bibliography: hs3.bib
 This section contains composite distributions in the sense that they refer to other distribution which they combine or modify in some way. 
 
 
-#### Mixture distribution
+#### Mixture distribution {#sec:mixture-distribution label="sec:mixture-distribution"}
 
 The mixture distribution, sometimes called addition of distributions, is a (weighted) sum of distributions $f_i(\vec{x})$, depending on the same variable(s) $\vec{x}$: 
 
@@ -61,7 +61,81 @@ If all coefficients are given, their sum is used as the expected number of event
 -   `type`: `mixture_model`
 -   `summands`: array of names referencing model distributions
 -   `coefficients`: array of names of coefficients $c_i$ or numbers
--   `extended`: boolean denoting whether this is an extended model
+-   `extended`: boolean denoting whether this is an extended model  
+
+
+#### Indexed distribution {#sec:indexed-distribution label="sec:indexed-distribution"}
+
+The indexed distribution combines several sub-distributions, selected by the value $c$ of the categorical variable named by `index`:
+
+$$
+\begin{aligned}
+\text{IndexedPdf}(x, c) &= \text{PDF}(m_{c}(\theta), x)
+\end{aligned}
+$$
+
+where $m_c$ is the sub-distribution assigned to the category $c$.
+
+An indexed distribution is a struct defined by the following components:
+
+- `name`: custom string
+- `type`: `indexed_dist`
+- `index`: name of the categorical variable selecting the sub-distribution. It [must]{.smallcaps} refer to a categorical axis of the data this distribution is paired with, or to a parameter with a categorical domain
+- `dimensions`: array of structs, each assigning one category value to the distribution used for it:
+    - `category`: string, one of the values of the categorical variable named by `index`
+    - `dist`: name of the sub-distribution used for this value of `category`
+
+This standard does not distinguish the two cases: if `index` is bound to a categorical axis of the paired data, evaluation is dispatched per data entry, which is the typical construction for simultaneous fits of several measurement regions; if `index` is a model parameter, the single sub-distribution matching its current value is evaluated. Both follow from the definition above.
+
+The distributions referenced by `dimensions` [may]{.smallcaps} each have different variate names, since only one of them is evaluated for any given category value. `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this distribution.
+
+```json title="Example: Indexed distribution, per-channel sub-distributions"
+{
+    "name":"channels",
+    "type":"indexed_dist",
+    "index":"channel",
+    "dimensions":[
+        {"category":"SR", "dist":"sr"},
+        {"category":"CR", "dist":"cr"}
+    ]
+}
+```
+
+```json title="Example: Indexed distribution, alternative shape hypotheses"
+{
+    "name":"bkg_choice",
+    "type":"indexed_dist",
+    "index":"bkg_function",
+    "dimensions":[
+        {"category":"poly1", "dist":"bkg_poly1"},
+        {"category":"poly2", "dist":"bkg_poly2"},
+        {"category":"exp1", "dist":"bkg_exp1"}
+    ]
+}
+```
+
+The `dist` of a dimension [may]{.smallcaps} itself be an indexed distribution using a different `index`, evaluating $m_{c_1,c_2}$. This is how a distribution is matched to an indexed data set spanning several categorical axes (see [Data](#sec:data){reference-type="ref" reference="sec:data"}). The order in which the indices are nested is not significant.
+
+```json title="Example: Nested indexed distributions"
+{
+    "name":"region_year",
+    "type":"indexed_dist",
+    "index":"region",
+    "dimensions":[
+        {"category":"SR", "dist":"sr_by_year"},
+        {"category":"CR", "dist":"cr_by_year"}
+    ]
+},
+{
+    "name":"sr_by_year",
+    "type":"indexed_dist",
+    "index":"year",
+    "dimensions":[
+        {"category":"2016", "dist":"sr_2016"},
+        {"category":"2017", "dist":"sr_2017"}
+    ]
+}
+```
 
 
 #### Product distribution {#sec:product-distribution label="sec:product-distribution"} 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -70,22 +70,24 @@ The indexed distribution combines several sub-distributions, selected by the val
 
 $$
 \begin{aligned}
-\text{IndexedPdf}(x, c) &= \text{PDF}(m_{c}(\theta), x)
+\text{IndexedPdf}(x, c) &= w_c \cdot \text{PDF}(m_{c}(\theta), x)
 \end{aligned}
 $$
 
-where $m_c$ is the sub-distribution assigned to the category $c$.
+where $m_c$ is the sub-distribution assigned to the category $c$. As with any other named variable in this standard, whether $c$ is currently bound to a categorical axis of paired data, to a parameter, or is being sampled, is not decided by this definition. This is what allows the same construction to cover both simultaneous fits of several measurement regions ($c$ bound to an axis of the paired data, evaluation dispatched per data entry) and discrete profiling over alternative shape hypotheses ($c$ a parameter with a categorical domain, a single sub-distribution evaluated).
+
+For a given, fixed value of $c$, $w_c = 1$ and $\text{IndexedPdf}$ is normalized in $x$, since $\text{PDF}(m_c(\theta), x)$ is the normalized PDF of $m_c$.
+
+Sampling $(x, c)$ jointly from `indexed_dist` additionally requires a distribution over $c$. This is defined only if every sub-distribution referenced by `dimensions` is extended: $w_c = \nu_c / \sum_{c'} \nu_{c'}$, with $\nu_c$ the expected number of events of the sub-distribution assigned to $c$. $\text{IndexedPdf}$ is then a properly normalized joint density in $(x, c)$, itself extended with expected event count $\sum_c \nu_c$, and [may]{.smallcaps} be sampled by drawing $c$ with probability $w_c$ and then $x$ from $m_c$. `indexed_dist` [must not]{.smallcaps} be sampled directly if any sub-distribution referenced by `dimensions` is not extended.
 
 An indexed distribution is a struct defined by the following components:
 
-- `name`: custom string
+- `name`: custom unique string
 - `type`: `indexed_dist`
-- `index`: name of the categorical variable selecting the sub-distribution. It [must]{.smallcaps} refer to a categorical axis of the data this distribution is paired with, or to a parameter with a categorical domain
+- `index`: name of the categorical variable selecting the sub-distribution
 - `dimensions`: array of structs, each assigning one category value to the distribution used for it:
     - `category`: string, one of the values of the categorical variable named by `index`
     - `dist`: name of the sub-distribution used for this value of `category`
-
-This standard does not distinguish the two cases: if `index` is bound to a categorical axis of the paired data, evaluation is dispatched per data entry, which is the typical construction for simultaneous fits of several measurement regions; if `index` is a model parameter, the single sub-distribution matching its current value is evaluated. Both follow from the definition above.
 
 The distributions referenced by `dimensions` [may]{.smallcaps} each have different variate names, since only one of them is evaluated for any given category value. `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this distribution.
 

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -64,38 +64,36 @@ If all coefficients are given, their sum is used as the expected number of event
 -   `extended`: boolean denoting whether this is an extended model  
 
 
-#### Indexed distribution {#sec:indexed-distribution label="sec:indexed-distribution"}
+#### Named joint distribution {#sec:named-joint-distribution label="sec:named-joint-distribution"}
 
-The indexed distribution combines several sub-distributions, selected by the value $c$ of the categorical variable named by `index`:
+> This is a specialized distribution type: the variable named by `axis` [must]{.smallcaps} be an observable. 
+
+The named joint distribution combines several sub-distributions $m_c$, selected by the value $c$ of the categorical axis of the paired data named by `axis`:
 
 $$
 \begin{aligned}
-\text{IndexedPdf}(x, c) &= w_c \cdot \text{PDF}(m_{c}(\theta), x)
+\text{NamedJointPdf}(x, c) &= w_c \cdot \text{PDF}(m_{c}(\theta), x)
 \end{aligned}
 $$
 
-where $m_c$ is the sub-distribution assigned to the category $c$. As with any other named variable in this standard, whether $c$ is currently bound to a categorical axis of paired data, to a parameter, or is being sampled, is not decided by this definition. This is what allows the same construction to cover both simultaneous fits of several measurement regions ($c$ bound to an axis of the paired data, evaluation dispatched per data entry) and discrete profiling over alternative shape hypotheses ($c$ a parameter with a categorical domain, a single sub-distribution evaluated).
+If not every sub-distribution referenced by `dimensions` is extended, $w_c = 1$: $\text{NamedJointPdf}(x, c)$ is the normalized PDF of $m_c$ in $x$, a conditional density given $c$, with $c$ treated as given per data entry, like any other coordinate of the paired data, rather than being modeled itself. This is the typical construction for simultaneous fits of several measurement regions, with evaluation dispatched per data entry. In this case `named_joint_dist` [must not]{.smallcaps} be sampled in $c$.
 
-For a given, fixed value of $c$, $w_c = 1$ and $\text{IndexedPdf}$ is normalized in $x$, since $\text{PDF}(m_c(\theta), x)$ is the normalized PDF of $m_c$.
-
-Sampling $(x, c)$ jointly from `indexed_dist` additionally requires a distribution over $c$. This is defined only if every sub-distribution referenced by `dimensions` is extended: $w_c = \nu_c / \sum_{c'} \nu_{c'}$, with $\nu_c$ the expected number of events of the sub-distribution assigned to $c$. $\text{IndexedPdf}$ is then a properly normalized joint density in $(x, c)$, itself extended with expected event count $\sum_c \nu_c$, and [may]{.smallcaps} be sampled by drawing $c$ with probability $w_c$ and then $x$ from $m_c$. `indexed_dist` [must not]{.smallcaps} be sampled directly if any sub-distribution referenced by `dimensions` is not extended.
-
-An indexed distribution is a struct defined by the following components:
+If every sub-distribution referenced by `dimensions` is extended, with expected event count $\nu_c$ for category $c$, then $w_c = \nu_c / \nu$ with $\nu = \sum_c \nu_c$. $\text{NamedJointPdf}$ is then a normalized joint density in $(x, c)$, and `named_joint_dist` is itself extended with expected event count $\nu$. It [may]{.smallcaps} be sampled over $(x, c)$: a count $n$ is drawn from a Poisson distribution with mean $\nu$, and each of the $n$ outcomes by drawing $c$ with probability $w_c$ and then $x$ from $m_c$. This is equivalent to one Poisson point process per category, with rate $\nu_c$ and underlying distribution $m_c$, so counts and values across categories are conditionally independent given $\theta$.
 
 - `name`: custom unique string
-- `type`: `indexed_dist`
-- `index`: name of the categorical variable selecting the sub-distribution
+- `type`: `named_joint_dist`
+- `axis`: name of the categorical axis of the paired data selecting the sub-distribution
 - `dimensions`: array of structs, each assigning one category value to the distribution used for it:
-    - `category`: string, one of the values of the categorical variable named by `index`
+    - `category`: string, one of the values of the categorical variable named by `axis`
     - `dist`: name of the sub-distribution used for this value of `category`
 
-The distributions referenced by `dimensions` [may]{.smallcaps} each have different variate names, since only one of them is evaluated for any given category value. `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this distribution.
+The distributions referenced by `dimensions` [must]{.smallcaps} describe mutually independent probability spaces. They [may]{.smallcaps} each have different variate names, and [may]{.smallcaps} equally share variates: since the value of `axis` is itself part of the outcome, each outcome belongs to exactly one category, and the categories themselves separate the spaces. `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this distribution.
 
-```json title="Example: Indexed distribution, per-channel sub-distributions"
+```json title="Example: Named joint distribution for a multi-channel model"
 {
     "name":"channels",
-    "type":"indexed_dist",
-    "index":"channel",
+    "type":"named_joint_dist",
+    "axis":"channel",
     "dimensions":[
         {"category":"SR", "dist":"sr"},
         {"category":"CR", "dist":"cr"}
@@ -103,38 +101,39 @@ The distributions referenced by `dimensions` [may]{.smallcaps} each have differe
 }
 ```
 
-```json title="Example: Indexed distribution, alternative shape hypotheses"
+
+#### Categorical distribution
+
+> This is a specialized distribution type: the variable named by `axis` [must]{.smallcaps} be a parameter. 
+
+The categorical distribution selects one of several sub-distributions $m_c$ by the value $c$ of the categorical parameter named by `axis`, and evaluates it conditioned on that fixed value:
+
+$$
+\begin{aligned}
+\text{CategoricalPdf}(x, c) &= \text{PDF}(m_{c}(\theta), x)
+\end{aligned}
+$$
+
+This is a conditional density in $x$ given the current value of $c$, not a joint density over $(x, c)$: it is normalized in $x$ for each $c$, since $\text{PDF}(m_c(\theta), x)$ is the normalized PDF of $m_c$, but it does not itself define a distribution over $c$. This is the typical construction for discrete profiling over alternative shape hypotheses, and `categorical_dist` [must not]{.smallcaps} be sampled in $c$. If the sub-distributions referenced by `dimensions` are extended, `categorical_dist` is extended with the expected event count $\nu_c$ of the selected sub-distribution.
+
+- `name`: custom unique string
+- `type`: `categorical_dist`
+- `axis`: name of the categorical parameter selecting the sub-distribution
+- `dimensions`: array of structs, each assigning one category value to the distribution used for it:
+    - `category`: string, one of the values of the categorical variable named by `axis`
+    - `dist`: name of the sub-distribution used for this value of `category`
+
+The distributions referenced by `dimensions` [must]{.smallcaps} describe the same probability space: they share the variate $x$ and are alternative descriptions of it. `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this distribution.
+
+```json title="Example: Categorical distribution, alternative shape hypotheses"
 {
     "name":"bkg_choice",
-    "type":"indexed_dist",
-    "index":"bkg_function",
+    "type":"categorical_dist",
+    "axis":"bkg_function",
     "dimensions":[
         {"category":"poly1", "dist":"bkg_poly1"},
         {"category":"poly2", "dist":"bkg_poly2"},
         {"category":"exp1", "dist":"bkg_exp1"}
-    ]
-}
-```
-
-The `dist` of a dimension [may]{.smallcaps} itself be an indexed distribution using a different `index`, evaluating $m_{c_1,c_2}$. This is how a distribution is matched to an indexed data set spanning several categorical axes (see [Data](#sec:data){reference-type="ref" reference="sec:data"}). The order in which the indices are nested is not significant.
-
-```json title="Example: Nested indexed distributions"
-{
-    "name":"region_year",
-    "type":"indexed_dist",
-    "index":"region",
-    "dimensions":[
-        {"category":"SR", "dist":"sr_by_year"},
-        {"category":"CR", "dist":"cr_by_year"}
-    ]
-},
-{
-    "name":"sr_by_year",
-    "type":"indexed_dist",
-    "index":"year",
-    "dimensions":[
-        {"category":"2016", "dist":"sr_2016"},
-        {"category":"2017", "dist":"sr_2017"}
     ]
 }
 ```

--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -66,9 +66,9 @@ If all coefficients are given, their sum is used as the expected number of event
 
 #### Named joint distribution {#sec:named-joint-distribution label="sec:named-joint-distribution"}
 
-> This is a specialized distribution type: the variable named by `axis` [must]{.smallcaps} be an observable. 
+> This is a specialized distribution type: the variable named by `categorical_variate` [must]{.smallcaps} be an observable. 
 
-The named joint distribution combines several sub-distributions $m_c$, selected by the value $c$ of the categorical axis of the paired data named by `axis`:
+The named joint distribution combines several sub-distributions $m_c$, selected by the value $c$ of the categorical axis of the paired data named by `categorical_variate`:
 
 $$
 \begin{aligned}
@@ -82,18 +82,18 @@ If every sub-distribution referenced by `dimensions` is extended, with expected 
 
 - `name`: custom unique string
 - `type`: `named_joint_dist`
-- `axis`: name of the categorical axis of the paired data selecting the sub-distribution
+- `categorical_variate`: name of the categorical axis of the paired data selecting the sub-distribution
 - `dimensions`: array of structs, each assigning one category value to the distribution used for it:
-    - `category`: string, one of the values of the categorical variable named by `axis`
+    - `category`: string, one of the values of the categorical variable named by `categorical_variate`
     - `dist`: name of the sub-distribution used for this value of `category`
 
-The distributions referenced by `dimensions` [must]{.smallcaps} describe mutually independent probability spaces. They [may]{.smallcaps} each have different variate names, and [may]{.smallcaps} equally share variates: since the value of `axis` is itself part of the outcome, each outcome belongs to exactly one category, and the categories themselves separate the spaces. `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this distribution.
+The distributions referenced by `dimensions` [must]{.smallcaps} describe mutually independent probability spaces. They [may]{.smallcaps} each have different variate names, and [may]{.smallcaps} equally share variates: since the value of `categorical_variate` is itself part of the outcome, each outcome belongs to exactly one category, and the categories themselves separate the spaces. `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this distribution.
 
 ```json title="Example: Named joint distribution for a multi-channel model"
 {
     "name":"channels",
     "type":"named_joint_dist",
-    "axis":"channel",
+    "categorical_variate":"channel",
     "dimensions":[
         {"category":"SR", "dist":"sr"},
         {"category":"CR", "dist":"cr"}
@@ -104,9 +104,9 @@ The distributions referenced by `dimensions` [must]{.smallcaps} describe mutuall
 
 #### Categorical distribution
 
-> This is a specialized distribution type: the variable named by `axis` [must]{.smallcaps} be a parameter. 
+> This is a specialized distribution type: the variable named by `categorical_parameter` [must]{.smallcaps} be a parameter. 
 
-The categorical distribution selects one of several sub-distributions $m_c$ by the value $c$ of the categorical parameter named by `axis`, and evaluates it conditioned on that fixed value:
+The categorical distribution selects one of several sub-distributions $m_c$ by the value $c$ of the categorical parameter named by `categorical_parameter`, and evaluates it conditioned on that fixed value:
 
 $$
 \begin{aligned}
@@ -118,9 +118,9 @@ This is a conditional density in $x$ given the current value of $c$, not a joint
 
 - `name`: custom unique string
 - `type`: `categorical_dist`
-- `axis`: name of the categorical parameter selecting the sub-distribution
+- `categorical_parameter`: name of the categorical parameter selecting the sub-distribution
 - `dimensions`: array of structs, each assigning one category value to the distribution used for it:
-    - `category`: string, one of the values of the categorical variable named by `axis`
+    - `category`: string, one of the values of the categorical variable named by `categorical_parameter`
     - `dist`: name of the sub-distribution used for this value of `category`
 
 The distributions referenced by `dimensions` [must]{.smallcaps} describe the same probability space: they share the variate $x$ and are alternative descriptions of it. `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this distribution.
@@ -129,7 +129,7 @@ The distributions referenced by `dimensions` [must]{.smallcaps} describe the sam
 {
     "name":"bkg_choice",
     "type":"categorical_dist",
-    "axis":"bkg_function",
+    "categorical_parameter":"bkg_function",
     "dimensions":[
         {"category":"poly1", "dist":"bkg_poly1"},
         {"category":"poly2", "dist":"bkg_poly2"},

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -49,6 +49,35 @@ $$
 -   `type`: `sum` 
 -   `summands`: array of names of the elements of the sum or numbers. 
 
+### Indexed Function
+A value $f_c$ selected by the value $c$ of a categorical variable.  
+
+$$
+\begin{aligned} \text{Indexed}(c) &= f_c \end{aligned}
+$$
+
+-   `name`: custom unique string
+-   `type`: `indexed`
+-   `index`: name of the categorical variable selecting the value
+-   `dimensions`: array of structs, each assigning one category value to the element used for it:
+    -   `category`: string, one of the values of the categorical variable named by `index`
+    -   `function`: the element used for this value of `category`. As for any other function parameter key, this is either a number or a string referencing another object, such as a function or a parameter. It [may]{.smallcaps} in particular reference another indexed function using a different `index`, so that nesting indexed functions gives a value selected by several categorical variables.
+
+`dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this function.
+
+```json title="Example: Indexed function"
+{
+	"name" : "shape_choice_offset",
+	"type" : "indexed",
+	"index" : "bkg_function",
+	"dimensions" : [
+		{ "category":"poly1", "function":1.0 },
+		{ "category":"poly2", "function":"poly2_offset" },
+		{ "category":"exp1", "function":0.5 }
+	]
+}
+```
+
 ### Polynomial Function
 The polynomial function is defined as
 

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -49,7 +49,7 @@ $$
 -   `type`: `sum` 
 -   `summands`: array of names of the elements of the sum or numbers. 
 
-### Indexed Function
+### Indexed Function {#func:indexed-function label="func:indexed-function"}
 A value $f_c$ selected by the value $c$ of a categorical variable.  
 
 $$

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -58,7 +58,7 @@ $$
 
 -   `name`: custom unique string
 -   `type`: `indexed`
--   `index`: name of the categorical variable selecting the value
+-   `index`: name of the categorical variable selecting the value. As with [Indexed distribution](#sec:indexed-distribution){reference-type="ref" reference="sec:indexed-distribution"}, this standard does not decide whether `index` is bound to a categorical axis of paired data or to a parameter; that follows from how the enclosing object is used.
 -   `dimensions`: array of structs, each assigning one category value to the element used for it:
     -   `category`: string, one of the values of the categorical variable named by `index`
     -   `function`: the element used for this value of `category`. As for any other function parameter key, this is either a number or a string referencing another object, such as a function or a parameter. It [may]{.smallcaps} in particular reference another indexed function using a different `index`, so that nesting indexed functions gives a value selected by several categorical variables.

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -58,7 +58,7 @@ $$
 
 -   `name`: custom unique string
 -   `type`: `indexed`
--   `index`: name of the categorical variable selecting the value. As with [Indexed distribution](#sec:indexed-distribution){reference-type="ref" reference="sec:indexed-distribution"}, this standard does not decide whether `index` is bound to a categorical axis of paired data or to a parameter; that follows from how the enclosing object is used.
+-   `index`: name of the categorical variable selecting the value. This standard does not decide whether `index` is bound to a categorical axis of paired data or to a parameter; that follows from how the enclosing object is used.
 -   `dimensions`: array of structs, each assigning one category value to the element used for it:
     -   `category`: string, one of the values of the categorical variable named by `index`
     -   `function`: the element used for this value of `category`. As for any other function parameter key, this is either a number or a string referencing another object, such as a function or a parameter. It [may]{.smallcaps} in particular reference another indexed function using a different `index`, so that nesting indexed functions gives a value selected by several categorical variables.

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -58,10 +58,10 @@ $$
 
 -   `name`: custom unique string
 -   `type`: `categorical`
--   `categorical_parameter`: name of the categorical variable selecting the value. This standard does not decide whether `categorical_parameter` is bound to a categorical axis of paired data or to a parameter; that follows from how the enclosing object is used.
+-   `categorical_variable`: name of the categorical variable selecting the value. This standard does not decide whether `categorical_variable` is bound to a categorical axis of paired data or to a parameter; that follows from how the enclosing object is used.
 -   `dimensions`: array of structs, each assigning one category value to the element used for it:
-    -   `category`: string, one of the values of the categorical variable named by `categorical_parameter`
-    -   `function`: the element used for this value of `category`. As for any other function parameter key, this is either a number or a string referencing another object, such as a function or a parameter. It [may]{.smallcaps} in particular reference another categorical function using a different `categorical_parameter`, so that nesting categorical functions gives a value selected by several categorical variables.
+    -   `category`: string, one of the values of the categorical variable named by `categorical_variable`
+    -   `function`: the element used for this value of `category`. As for any other function parameter key, this is either a number or a string referencing another object, such as a function or a parameter. It [may]{.smallcaps} in particular reference another categorical function using a different `categorical_variable`, so that nesting categorical functions gives a value selected by several categorical variables.
 
 `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this function.
 
@@ -69,7 +69,7 @@ $$
 {
 	"name" : "shape_choice_offset",
 	"type" : "categorical",
-	"categorical_parameter" : "bkg_function",
+	"categorical_variable" : "bkg_function",
 	"dimensions" : [
 		{ "category":"poly1", "function":1.0 },
 		{ "category":"poly2", "function":"poly2_offset" },

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -49,27 +49,27 @@ $$
 -   `type`: `sum` 
 -   `summands`: array of names of the elements of the sum or numbers. 
 
-### Indexed Function {#func:indexed-function label="func:indexed-function"}
+### Categorical Function {#func:categorical-function label="func:categorical-function"}
 A value $f_c$ selected by the value $c$ of a categorical variable.  
 
 $$
-\begin{aligned} \text{Indexed}(c) &= f_c \end{aligned}
+\begin{aligned} \text{Categorical}(c) &= f_c \end{aligned}
 $$
 
 -   `name`: custom unique string
--   `type`: `indexed`
--   `index`: name of the categorical variable selecting the value. This standard does not decide whether `index` is bound to a categorical axis of paired data or to a parameter; that follows from how the enclosing object is used.
+-   `type`: `categorical`
+-   `categorical_parameter`: name of the categorical variable selecting the value. This standard does not decide whether `categorical_parameter` is bound to a categorical axis of paired data or to a parameter; that follows from how the enclosing object is used.
 -   `dimensions`: array of structs, each assigning one category value to the element used for it:
-    -   `category`: string, one of the values of the categorical variable named by `index`
-    -   `function`: the element used for this value of `category`. As for any other function parameter key, this is either a number or a string referencing another object, such as a function or a parameter. It [may]{.smallcaps} in particular reference another indexed function using a different `index`, so that nesting indexed functions gives a value selected by several categorical variables.
+    -   `category`: string, one of the values of the categorical variable named by `categorical_parameter`
+    -   `function`: the element used for this value of `category`. As for any other function parameter key, this is either a number or a string referencing another object, such as a function or a parameter. It [may]{.smallcaps} in particular reference another categorical function using a different `categorical_parameter`, so that nesting categorical functions gives a value selected by several categorical variables.
 
 `dimensions` [need not]{.smallcaps} cover every value of the categorical variable; categories without a matching entry are undefined for this function.
 
-```json title="Example: Indexed function"
+```json title="Example: categorical function"
 {
 	"name" : "shape_choice_offset",
-	"type" : "indexed",
-	"index" : "bkg_function",
+	"type" : "categorical",
+	"categorical_parameter" : "bkg_function",
 	"dimensions" : [
 		{ "category":"poly1", "function":1.0 },
 		{ "category":"poly2", "function":"poly2_offset" },

--- a/docs/chapters/2.3_data.md
+++ b/docs/chapters/2.3_data.md
@@ -160,3 +160,44 @@ This type can also be used to store pre-processed data utilizing the `uncertaint
   }
 ]
 ```
+
+### Indexed data set
+
+Indexed data sets merge multiple data structs into one. The sub-data sets can be of any `type` described above and [may]{.smallcaps} have overlapping or non-overlapping `axes`.  
+An indexed data set is defined with the components:  
+
+- `name`: custom string
+- `type`: `indexed`
+- `axes`: array of categorical axes as defined in [Axis Specifications](#sec:axes), spanning the collection of sub-data sets. Continuous axes [must not]{.smallcaps} be present.
+- `dimensions`: array of structs, each assigning one sub-data set to a coordinate in the space spanned by `axes`. Each struct [must]{.smallcaps} have the components:
+    - `coordinates`: array of values, one per entry of `axes`, positionally matched: `coordinates[i]` gives the value along `axes[i]`, and [must]{.smallcaps} be one of the values listed in `axes[i].categories`. No two entries of `dimensions` [may]{.smallcaps} specify the same `coordinates` tuple.
+    - `dataset`: `name` of the referenced data set
+
+The space spanned by `axes` [need not]{.smallcaps} be fully covered by `dimensions`.
+
+```json title="Example: Indexed data set"
+"data":[
+  {
+    "name":"indexed_data",
+    "type":"indexed",
+    "axes":[
+      { "name":"regions", "categories":["SR","CR","VR"] },
+      { "name":"observables", "categories":["physics","global"] }
+    ],
+    "dimensions":[
+      { "coordinates":["SR","physics"], "dataset":"data_sr" },
+      { "coordinates":["CR","physics"], "dataset":"data_cr" },
+      { "coordinates":["VR","physics"], "dataset":"data_vr" },
+      { "coordinates":["SR","global"],  "dataset":"global_obs_sr" },
+      { "coordinates":["CR","global"],  "dataset":"global_obs_cr" }
+    ]
+  },
+  { "name":"data_sr", "type":"binned", "contents":[...], "axes":[...] },
+  { "name":"data_cr", "type":"unbinned", "entries":[...], "axes":[...] },
+  { "name":"data_vr", "type":"unbinned", "entries":[...], "axes":[...] },
+  { "name":"global_obs_sr", "type":"unbinned", "entries":[...], "axes":[...] },
+  { "name":"global_obs_cr", "type":"unbinned", "entries":[...], "axes":[...] }
+]
+```
+
+Note that region `VR` has no `global` entry in `dimensions`: the coordinate `(VR, global)` is simply absent, which is valid.

--- a/docs/chapters/2.3_data.md
+++ b/docs/chapters/2.3_data.md
@@ -161,13 +161,13 @@ This type can also be used to store pre-processed data utilizing the `uncertaint
 ]
 ```
 
-### Indexed data set
+### Combined data set
 
-Indexed data sets merge multiple data structs into one. The sub-data sets can be of any `type` described above and [may]{.smallcaps} have overlapping or non-overlapping `axes`.  
-An indexed data set is defined with the components:  
+Combined data sets merge multiple data structs into one. The sub-data sets can be of any `type` described above and [may]{.smallcaps} have overlapping or non-overlapping `axes`.  
+A combined data set is defined with the components:  
 
 - `name`: custom string
-- `type`: `indexed`
+- `type`: `combined`
 - `axes`: array of categorical axes as defined in [Axis Specifications](#sec:axes), spanning the collection of sub-data sets. Continuous axes [must not]{.smallcaps} be present.
 - `dimensions`: array of structs, each assigning one sub-data set to a coordinate in the space spanned by `axes`. Each struct [must]{.smallcaps} have the components:
     - `coordinates`: array of values, one per entry of `axes`, positionally matched: `coordinates[i]` gives the value along `axes[i]`, and [must]{.smallcaps} be one of the values listed in `axes[i].categories`. No two entries of `dimensions` [may]{.smallcaps} specify the same `coordinates` tuple.
@@ -175,11 +175,11 @@ An indexed data set is defined with the components:
 
 The space spanned by `axes` [need not]{.smallcaps} be fully covered by `dimensions`.
 
-```json title="Example: Indexed data set"
+```json title="Example: Combined data set"
 "data":[
   {
-    "name":"indexed_data",
-    "type":"indexed",
+    "name":"combined_data",
+    "type":"combined",
     "axes":[
       { "name":"regions", "categories":["SR","CR","VR"] },
       { "name":"observables", "categories":["physics","global"] }


### PR DESCRIPTION
## Summary

> This is PR 2/3 in an effort to split up #105 into smaller, independently reviewable pieces. This part covers indexed data sets as well as indexed distributions and functions.

Building on the categorical axes from #108, this adds the constructs that combine data sets and distributions across them. Such a combination can already be expressed as a likelihood, i.e. a paired list $\{(m_i, x_i)\}$. However a likelihood cannot be sampled from, since sampling is defined on a distribution. A paired list also has no place to record the index itself, neither its name nor its category labels, so what is one indexed object in the engines comes back as $N$ unrelated pairs. Indexed data sets and indexed distributions carry the same content as a single data set and a single distribution, with the index explicit.

Whether the index is an observable or a model parameter is not declared: it follows from how the model is paired with data in a `likelihood`. One definition therefore covers both simultaneous multi-region fits and discrete profiling over alternative shape hypotheses. `indexed_dist` maps onto `RooSimultaneous`, now that most of the functionality of `RooMultiPdf` has been merged into it (root-project/root#23142), and the `indexed` function onto [`RooMultiReal`](https://root.cern.ch/doc/v640/RooMultiReal_8h_source.html).

> **Note**: `combine` uses `RooMultiPdf` for discrete profiling over shape hypothesis and implements additional penalty terms tied to the different choices of shapes (dependent on the shapes complexity). These could be serialized as an `indexed` function used by a distribution in `aux_distributions`. Once an implementation for this is ready in RooFit/Combine we could add non-normative prose on this to the standard.

#### What changed
- `2.3_data.md`: adds the `indexed` data set which comprises of sub-data sets of any type, each assigned to a `coordinates` tuple in the space spanned by categorical `axes` as defined in the *Axis Specifications* section.
- `2.1.2_composite_distributions.md`: adds `indexed_dist`, $\text{PDF}(m_c(\theta), x)$, with the sub-distribution selected by the categorical variable named by `index` and one entry per category in `dimensions`. A sub-distribution may itself be an `indexed_dist` on a different index, in any order, so that nesting matches a data set spanned by several categorical axes.
- `2.2_functions.md`: adds the `indexed` function, structurally identical to `indexed_dist`
