### PR TITLE
Add step, histogram, and bin-volume primitives

### DIFF
--- a/docs/chapters/2.1.1_fundamental_distributions.md
+++ b/docs/chapters/2.1.1_fundamental_distributions.md
@@ -319,6 +319,21 @@ The distribution is normalized by the implementation, so a normalization term [s
 {% include-markdown "parts/histfactory.md" %}
 
 
+#### Histogram distribution
+
+The histogram distribution is a step function with bin values $c_i$ on the bins $b_i$ of a binning $b$ of the variables $\mathbf{x}$:
+
+$$
+\begin{aligned} \text{HistogramPdf}(\mathbf{x}) = \frac{1}{\ensuremath{\mathcal{M}}} \, c_i \quad \text{for } \mathbf{x} \in b_i \end{aligned}
+$$
+
+The binning $b$ follows the rules for binned data in [Axis Specifications](#sec:axes). Which bin a point on a bin boundary belongs to is at the discretion of the creator of the model and thus not defined. Outside the domain spanned by the axes, the value is undefined.
+
+-   `name`: custom unique string
+-   `type`: `histogram_dist`
+-   `data`: struct with the components `axes` and `contents`. `axes` is an array of axis structs following the rules for binned data in [Axis Specifications](#sec:axes), defining the variables $\mathbf{x}$ and the binning $b$. `contents` is an array of the bin values $c_i$, one per bin.
+
+
 #### Relativistic Breit-Wigner distribution
 
 The relativistic Breit-Wigner distribution describes the line-shape of a resonance in the mass spectrum of a two-particle system. It is assumed that the resonance can decay into a list of channels. 

--- a/docs/chapters/2.2_functions.md
+++ b/docs/chapters/2.2_functions.md
@@ -125,3 +125,45 @@ A generic function is defined by an expression. The expression must be a valid H
 -   `name`: custom unique string 
 -   `type`: `generic_function` 
 -   `expression`: a string with a generic mathematical expression.     Simple mathematical syntax common to programming languages should be     used here, such as `x-2*y+z`. For any non-elementary operations, the     behavior is undefined. 
+
+### Step Function
+A step function takes a constant value $c_i$ on each bin $b_i$ of a binning $b$ of the variables $\mathbf{x}$:
+
+$$
+\begin{aligned} \text{Step}(\mathbf{x}) &= c_i \quad \text{for } \mathbf{x} \in b_i \end{aligned}
+$$
+
+The binning $b$ follows the rules for binned data in [Axis Specifications](#sec:axes). Which bin a point on a bin boundary belongs to is at the discretion of the creator of the model and thus not defined. Outside the domain spanned by the axes, the value is undefined.
+
+The bin values $c_i$ are given either as fixed numbers in `data`, or as one value or reference per bin in `parameters`. Exactly one of the two forms [must]{.smallcaps} be used.
+
+-   `name`: custom unique string
+-   `type`: `step`
+-   `data`: struct with the components `axes` and `contents`. `axes` is an array of axis structs following the rules for binned data in [Axis Specifications](#sec:axes), defining the variables $\mathbf{x}$ and the binning $b$. `contents` is an array of the bin values $c_i$, one per bin. [must not]{.smallcaps} be used in conjunction with `axes`, `variables` or `parameters`.
+-   `axes`: array of axis structs defining the binning $b$, following the binned form in [Axis Specifications](#sec:axes). [must not]{.smallcaps} be used in conjunction with `data`.
+-   `variables`: array of names of the variables $\mathbf{x}$, one per entry of `axes`, in the same order. [must not]{.smallcaps} be used in conjunction with `data`.
+-   `parameters`: array of values or names of the bin values $c_i$, one per bin, in the same order as `contents` in `data` would be for the same `axes`. [must not]{.smallcaps} be used in conjunction with `data`.
+
+### Bin Volume Function
+The volume of the bin $b_i$ of a step function that contains $\mathbf{x}$, i.e. the product of the bin widths over all axes $a$:
+
+$$
+\begin{aligned} \text{BinVolume}(\mathbf{x}) &= \prod_a \left( u_{a,i} - l_{a,i} \right) \quad \text{for } \mathbf{x} \in b_i, \end{aligned}
+$$
+
+where $l_{a,i}$ and $u_{a,i}$ are the lower and upper edges of $b_i$ along axis $a$.
+
+-   `name`: custom unique string
+-   `type`: `binvolume`
+-   `histogram`: name of the step function whose binning $b$ is used
+
+### Inverse Bin Volume Function
+The inverse of the bin volume function:
+
+$$
+\begin{aligned} \text{InverseBinVolume}(\mathbf{x}) &= \frac{1}{\text{BinVolume}(\mathbf{x})} \end{aligned}
+$$
+
+-   `name`: custom unique string
+-   `type`: `inverse_binvolume`
+-   `histogram`: name of the step function whose binning $b$ is used


### PR DESCRIPTION
This PR adds the functions `step`, `(inverse_)binvolume` as well as `histogram_dist` to synchronize with ROOT PR [#22735](https://github.com/root-project/root/pull/22735).

However this is in conflict with the draft guidelines proposed in #111:

for `step` the type of serialized type from ROOT decides whether we have the components `data` or `axes`,`parameters`,`values`, which seems in conflict with #111's paragraph:
> An enum-like field may select between alternative methods when those methods operate on the same serialized state and the meaning of all other fields remains unchanged. The selected method may alter how that state is interpreted or evaluated, but shall not determine which disjoint set of fields is applicable.
>
> If different enum values require substantially different configuration data, parameterizations, or validity conditions, they [should]{.smallcaps} generally be represented as separate primitives rather than as variants of a single primitive.

Once #111 is merged/accepted we will probably need to readdress the `step` function (here and/or in ROOT)