### PR TITLE
fixing mkdocs build (reference to toplevels in author guideline)

### DIFF
--- a/docs/chapters/3.2_authoring_primitives.md
+++ b/docs/chapters/3.2_authoring_primitives.md
@@ -31,7 +31,7 @@ A primitive that only specializes an existing abstraction [should]{.smallcaps} p
 
 Primitive specifications extend the vocabulary of HS$^3$ but do not redefine the language itself.
 
-Primitive specifications may introduce new functions, distributions, or regular members of any other existing top-level HS$^3$ category (see Section @sec:toplevel). They shall not introduce new language constructs. In particular, a primitive shall not change its semantic role based on configuration or context, create or transform other serialized objects, or introduce control-flow, parser directives, or other metaprogramming facilities. Such proposals constitute extensions of the HS$^3$ language and require separate specification and review.
+Primitive specifications may introduce new functions, distributions, or regular members of any other existing top-level HS$^3$ category (see Section [Top-level components](#sec:toplevel)). They shall not introduce new language constructs. In particular, a primitive shall not change its semantic role based on configuration or context, create or transform other serialized objects, or introduce control-flow, parser directives, or other metaprogramming facilities. Such proposals constitute extensions of the HS$^3$ language and require separate specification and review.
 
 ### Required specification
 


### PR DESCRIPTION
this fixes the failing mkdocs build due to unknown reference.

@cburgard 