### PR TITLE
Histfactory Specfication Sync

### DIFF
--- a/docs/parts/histfactory.md
+++ b/docs/parts/histfactory.md
@@ -126,13 +126,12 @@ The components of a HistFactory distribution are:
     
 -   `name`: custom unique string 
 -   `type`: `histfactory_dist` 
--   `axes`: array of structs representing the axes. If given each struct     needs to have the component `name`. Further,     ([optional]{.smallcaps}) components are `max`, `min` and `nbins`,     or, alternatively, `edges`. The definition of the axes follows the     format for binned data (see Section 
-    [Binned Data](#sec:binned-data){reference-type="ref"     reference="sec:binned-data"}). 
+-   `axes`: array of axis structs. Each struct [must]{.smallcaps} contain `name`, `min`, `max` and exactly one of `nbins` or `edges`, following the [Axis Specifications](#sec:axes) for binned data. 
 -   `default_interpolation`: [optional]{.smallcaps} struct defining the default interpolation behaviour, for modifiers that do not specify it on their own. It has the components `type`, `in` and `out`, as described above.
 -   `samples`: array of structs containing the samples of this channel.     For details see below. 
 Struct of one sample:  
     -   `name`: ([optional]{.smallcaps}) custom string, unique within this     function 
-    -   `data`: struct containing the components `contents` and `errors`,     depicting the data contents and their errors. Both components are     arrays of the same length. 
+    -   `data`: struct containing the component `contents` and the ([optional]{.smallcaps}) component `errors`, depicting the sample contents and their per-bin uncertainties. Both components are arrays with length equal to the number of bins. If `errors` is absent, no per-bin uncertainty is associated with the sample. 
     -   `modifiers`: array of structs with each struct containing the modifiers for this sample.
     Struct of one modifier:
         -  `type`: type of the modifier

--- a/docs/parts/histfactory.md
+++ b/docs/parts/histfactory.md
@@ -33,9 +33,9 @@ The modifiers depend on a set of nuisance parameters $\theta$, where each modifi
 -   A *correlated shape systematic* or `histosys` modifier is an     additive modifier that adds or subtracts a constant step function     $\chi^f$, scaled with a single factor $\alpha$. The modifier     contains a `data` section, which contains the subsections     $\texttt{hi}$ and $\texttt{lo}$ that help to define the step     function $\chi^f$. They contain `contents`, which define the     bin-wise additions or subtractions for $\alpha=1$. The functional form of $\chi^f$ for intermediate and outlying $\alpha$ is set by the `interpolation` component, described below. Here,     $\theta_i=\alpha$. 
 -   A *normalization systematic* or `normsys` modifier is a     multiplicative modifier that scales the entire sample with the same     constant factor $f$ that is a function of $\alpha$. The modifier     contains a `data` section, which contains the values $\texttt{hi}$     and $\texttt{lo}$ that help to define $f$. There are different     functional forms that can be chosen for $f$. However, by convention     $f(\alpha=0)=1$, $f(\alpha=+1)=$"`hi`" and     $f(\alpha=-1)=$"`lo`". The functional form of $f$ for intermediate and outlying $\alpha$ is set by the `interpolation` component, described below. In this case, $\theta_i=\alpha$. 
 -   A *normalization factor* or `normfactor` modifier is a     multiplicative modifier that scales the entire sample in this region     with the value of the parameter $\mu$ itself. In this case,     $\theta_i=\mu$. 
--   The `staterror` modifier is a shorthand for encoding uncorrelated     statistical uncertainties on the values of the step-functions, using     a variant[^1] of the Barlow-Beeston Method [@barlowbeeston]. Here,     the relative uncertainty on the sum of all samples in this region     containing the `staterror` modifier is computed bin-by-bin. Then, a     constrained *uncorrelated shape systematic* (`shapesys`) is created,     encoding these relative uncertainties in the corresponding `Poisson`     (or `Gaussian`) constraint term. 
+-   The `staterror` modifier is a shorthand for encoding uncorrelated     statistical uncertainties on the values of the step-functions, using     a variant[^1] of the Barlow-Beeston Method [@barlowbeeston]. Here,     the relative uncertainty on the sum of all samples in this region     containing the `staterror` modifier is computed bin-by-bin. Then, a     constrained *uncorrelated shape systematic* (`shapesys`) is created,     encoding these relative uncertainties in the corresponding constraint     term. 
 
-The different modifies and their descriptions are also summarized in the following table: 
+The different modifiers and their descriptions are also summarized in the following table: 
 
 | **Type of Modifier**         | **Description**               | **Definition**                               | **Free Parameters**           | **Number of Free Parameters** |
 |------------------------------|-------------------------------|----------------------------------------------|-------------------------------|--------------------------------|
@@ -120,11 +120,7 @@ The following choices of $I$ are often used and showcase the resulting functiona
     - `{"type":"mult", "in":"poly6", "out":"poly1"}`
     - with $I_6(\theta; y_-, y_0, y_+) = 1 + I_4(\theta; y_-/y_0, 1, y_+/y_0)$
 
-Modifiers can be constrained. This is indicated by the component `constraint`, which identifies the type of the constraint term. In essence, the likelihood picks up a penalty term for changing the corresponding parameter too far away from its nominal value. The nominal value is, by convention, defined by the type of constraint, and is 0 for all modifiers of type `sys` (`histosys`, `normsys`) and is 1 for all modifiers of type `factor` (`normfactor`, `shapefactor`). The strength of the constraint is always such that the standard deviation of constraint distribution is $1$. 
-
-The supported constraint distributions, also called constraint types, are `Gauss` for a gaussian with unit width (a gaussian distribution with a variance of $1$), `Poisson` for a unit Poissonian (e.g. a continous Poissonian with a central value 1), or `LogNormal` for a unit LogNormal,. If a constraint is given, a corresponding distribution will be considered in addition to the `aux_likelihood` section of the likelihood, constraining the parameter to its nominal value. 
-
-An exception to this is provided by the `staterror` modifier as described above, and the `shapesys` for which a Poissonian constraint is defined with the central values defined as the squares of the values defined in `vals`. 
+Modifiers can be constrained. This is indicated by the component `constraints`, which names one or more distributions defined in the top-level component `distributions`. These are typically of type `gaussian_dist` or `poisson_dist`, but any distribution type is allowed. In essence, the likelihood picks up a penalty term for changing a constrained parameter too far away from its nominal value. 
 
 The components of a HistFactory distribution are: 
     
@@ -140,10 +136,14 @@ Struct of one sample:
     -   `modifiers`: array of structs with each struct containing the modifiers for this sample.
     Struct of one modifier:
         -  `type`: type of the modifier
-        -  `parameter` or `parameters`: defining a string or an array of strings, respectively. Relating to the name or names of parameters controlling this modifier. Two modifiers are correlated exactly if they share the same parameters as indicated by `parameter` or `parameters`. In such a case, it is mandatory that they share the same constraint term. If this is not the case, the behavior is undefined. 
+        -  `parameters`: array of strings naming the parameters controlling this modifier.
         -  `data`: [optional]{.smallcaps} relevant data for modifier. Its format depends on `type`, which is described above.
-        -  `constraint`: [optional]{.smallcaps} definition of how the modifier is constrained. Its format depends on `type`, which is described above.
+        -  `constraints`: [optional]{.smallcaps} array of distribution names, with one entry for each parameter in `parameters`. Individual entries [may]{.smallcaps} be `null`, leaving the corresponding parameter unconstrained. 
         -  `interpolation`: [optional]{.smallcaps} struct defining how the effect of the modifier is calculated within and outside of the boundaries $\theta=\pm 1$. It has the components `type`, `in` and `out` as described above. If this is omitted here for at least one modifier the top-level component `default_interpolation` becomes [required]{.smallcaps}.
+
+For modifiers controlling a single parameter (`histosys`, `normsys`, `normfactor`), the arrays `parameters` and `constraints` hold a single entry each. 
+
+Two modifiers are correlated if and only if they share the same parameters as indicated by `parameters`. In such a case, they [must]{.smallcaps} share the same constraint term in `constraints`. 
 
 ```json title="HistFactory"
 {
@@ -152,29 +152,29 @@ Struct of one sample:
   "axes": [ 
 	{ "max": 1.0, "min": 0.0, "name": "myRegion", "nbins": 2 } 
   ],
-  "name":"myChannel1",
   "default_interpolation": { "type": "mult", "in": "poly6", "out": "exp" },
   "samples": [
     { 
       "name": "mySignal",
       "data": { "contents": [ 0.5, 0.7 ], "errors": [ 0.1, 0.1 ] },
       "modifiers": [
-        { "parameter": "Lumi", "type": "normfactor" },
-        { "parameter": "mu_signal_strength", "type": "normfactor" },
-        { "constraint": "Gauss", "data": { "hi": 1.1, "lo": 0.9 }, 
-          "parameter": "my_normalization_systematic_1", 
+        { "parameters": ["Lumi"], "type": "normfactor" },
+        { "parameters": ["mu_signal_strength"], "type": "normfactor" },
+        { "constraints": ["my_normalization_systematic_1_constraint"], 
+          "data": { "hi": 1.1, "lo": 0.9 }, 
+          "parameters": ["my_normalization_systematic_1"], 
           "type": "normsys" },
-        { "constraint": "Poisson", "type": "staterror", 
+        { "constraints": ["gamma_stat_1_constraint", "gamma_stat_2_constraint"], "type": "staterror", 
           "parameters": ["gamma_stat_1","gamma_stat_2"]},
-        { "constraint": "Gauss", "type": "histosys", 
+        { "constraints": ["my_correlated_shape_systematic_1_constraint"], "type": "histosys", 
           "data": { 
             "hi": { "contents": [ -2.5, -3.1 ] }, 
             "lo": { "contents": [ 2.2, 3.7 ] } 
            }, 
            "interpolation": { "type": "add", "in": "poly6", "out": "poly1" },
-           "parameter": "my_correlated_shape_systematic_1" },
-        { "constraint": "Poisson", "data": { "vals": [ 0.0, 1.2 ] }, 
-          "parameter": "my_uncorrelated_shape_systematic_2", 
+           "parameters": ["my_correlated_shape_systematic_1"] },
+        { "constraints": ["my_shapesys_2_bin0_constraint", "my_shapesys_2_bin1_constraint"],
+          "parameters": ["my_uncorrelated_shape_systematic_2_bin0", "my_uncorrelated_shape_systematic_2_bin1"], 
           "type": "shapesys" }
       ]
     },


### PR DESCRIPTION
In `histfactory_dist`:
- Drops the singular `parameter`/`constraint`; modifiers use `parameters` and `constraints` (parallel arrays, `null` allowed for unconstrained parameters). Entries in `constraints` name a distribution in the top-level `distributions` list instead of a constraint *type* string.
- Drops `data.vals` of `shapesys`; the per-bin uncertainties live in the referenced constraint distributions.
- States the nominal-value convention (0 for `histosys`/`normsys`, 1 otherwise) and that `histosys`/`normsys` constraints [should] be unit Gaussians.
- `staterror`: defines the per-bin relative uncertainty from sample `contents`/`errors` and that its constraints [should] be a `barlow_beeston_lite_poisson_constraint_dist`.
- `axes` with the binned-data axis rules of §2.3 (`name`, `min`, `max` required; exactly one of `nbins` or `edges`) 
- marks sample `data.errors` as optional.

**Known gaps vs. ROOT master**: ROOT writes `data.vals` for `shapesys`, writes no `constraints` for `staterror` (rebuilds them on import), reads a channel-level `staterror` struct (`relThreshold`, `constraint_type`) that the spec does not define, and does not emit `barlow_beeston_lite_poisson_constraint_dist` yet.