### PR TITLE
Refactor axes

### DIFF
--- a/docs/chapters/2.1.2_composite_distributions.md
+++ b/docs/chapters/2.1.2_composite_distributions.md
@@ -170,7 +170,7 @@ $$
 
 
 
-The PDF of the bin-counts distribution at an outcome $x$ (a vector of length $k$, same as the number of bins) is 
+The PDF of the bin-counts distribution at an outcome $x$ (a vector of length $k$, same as the number of bins, ordered as defined in [Flattening of Binned Contents](#sec:axes-flattening){reference-type="ref" reference="sec:axes-flattening"}) is 
 
 
 
@@ -185,7 +185,7 @@ $$
      -   `type`: `bincounts_extended_dist` 
      -   `rate`: The global rate $\lambda$ 
      -   `dist`: The underlying distribution $m$ 
-     -   `axes`: a definition of the binning to be used, following the in [Binned Data](#sec:binned-data){reference-type="ref" reference="sec:binned-data"}. [optional]{.smallcaps} if `dist` is a binned distribution, in which case the same binning is used by default.  
+     -   `axes`: array of binned axes defining the binning to be used, as defined in [Binned Axes](#sec:axes-binned){reference-type="ref" reference="sec:axes-binned"}. [optional]{.smallcaps} if `dist` is a binned distribution, in which case the same binning is used by default.  
 	
 The name of the variable $x$ is taken from the underlying distribution. The underlying distribution [must]{.smallcaps} not be referred to from other components of the statistical model. 
 `bincounts_density_dist`: Specified via a non-normalized rate-density function $f$. Both the global-rate parameter and the underlying distribution are implicit: $\lambda = \int f(y) dy$ and $m = \text{DensityFunctionPdf}(f)$. 
@@ -196,4 +196,4 @@ More formally, the distribution corresponds to the inhomogeneous Poisson point p
     -   `type`: `bincounts_density_dist` 
     -   `x`: name of the variable $x$ 
     -   `density`: The rate-density function $f$ 
-    -   `axes`: a definition of the binning to be used, following the definitions in [Binned Data](#sec:binned-data){reference-type="ref" reference="sec:binned-data"}. 
+    -   `axes`: array of binned axes defining the binning to be used, as defined in [Binned Axes](#sec:axes-binned){reference-type="ref" reference="sec:axes-binned"}. 

--- a/docs/chapters/2.3_data.md
+++ b/docs/chapters/2.3_data.md
@@ -18,66 +18,13 @@ While data, in most settings, has no uncertainty attached to it, this standard *
 
 While it should always be preferred to publish "raw" data, allowing to include pre-processed data with corresponding uncertainties expands the possible applications considerably.
 
-### Axis Specifications {#sec:axes}
-Axes define the observable domain for data and PDFs. Every axis is either continuous or categorical. The kind of an axis is determined structurally: an axis struct [must]{.smallcaps} contain exactly one of the field pair `min`/`max` (continuous axis) or the field `categories` (categorical axis). Continuous axes additionally have type-specific requirements based on the data type they describe.
-
-#### Continuous Axes
-A continuous axis describes a real-valued observable. All continuous axes [must]{.smallcaps} include:
-
--   `name`: identifier matching the observable in the PDF
--   `min`: lower bound of the observable domain
--   `max`: upper bound of the observable domain
-
-These fields define the domain over which PDFs are normalized.
-
-**Note on normalization**: Any PDF depending on a continuous observable $x$ must be normalized over the domain $[\text{min}, \text{max}]$ defined by that observable's axis, not over $(-\infty, \infty)$.
-
-#### Categorical Axes
-A categorical axis describes a discrete-valued observable that takes one of a finite set of named states. A categorical axis [must]{.smallcaps} include:
-
-- `name`: identifier matching the categorical observable in the PDF
-- `categories`: array of unique strings enumerating the allowed values. `categories` defines a set: the order in which values appear in the array [must not]{.smallcaps} affect evaluation.
-
-The `categories` array itself defines the domain of the axis; the fields `min`, `max`, `nbins` and `edges` [must not]{.smallcaps} be present.  
-
-#### Forbidden Attributes
-The `const` attribute [must not]{.smallcaps} appear in axis specifications. All axes define observable domains, never fit parameters.
-
-#### Axis Types by Data Type
-
-**For Point Data:**  
-
--   Only continuous axes are permitted, carrying only the base fields (`name`, `min`, `max`) 
--   Binning fields (`nbins`, `edges`) [must not]{.smallcaps} be present
-
-**For Unbinned Data:**  
-
--   Continuous axes are required to carry base fields (`name`, `min`, `max`)
--   Binning fields (`nbins`, `edges`) [must not]{.smallcaps} be present
--   Categorical axes are permitted; the corresponding column of `entries` holds the respective row's category as one of the strings listed in `categories`
-
-**For Binned Data:**  
-
--   Continuous axes are required to carry base fields (`name`, `min`, `max`)
--   Each continuous axis [must]{.smallcaps} carry exactly one binning specification:
-    1. Regular binning: `nbins` (integer number of equal-width bins)
-    2. Irregular binning: `edges` (array of length $n+1$ bin boundaries)
--   Both `nbins` and `edges` [must not]{.smallcaps} be specified simultaneously
--   Neither `nbins` nor `edges` [must not]{.smallcaps} be omitted on a continuous axis
--   Categorical axes are permitted. A categorical axis acts as its own binning, with one bin per category in the order given by `categories`
-
-For irregular binning, the `edges` array must satisfy:
--   `edges[0] == min`
--   `edges[-1] == max`
--   All values must be in strictly ascending order
-
 ### Point Data
 Point data describes a measurement of a single number, with a possible uncertainty (error).
 
 -   `name`: custom string
 -   `type`: `point`
 -   `value`: value of this data point
--   `axes`: ([optional]{.smallcaps}) array of axis structs. Each struct must contain `name`, `min`, `max` as defined in [Axis Specifications](#sec:axes). When present, associates the point measurement with a specific observable domain.
+-   `axes`: ([optional]{.smallcaps}) array of continuous axes as defined in [Continuous Axes](#sec:axes-continuous). When present, associates the point measurement with a specific observable domain.
 -   `uncertainty`: ([optional]{.smallcaps}) uncertainty of this data point
 
 ```json title="Example: Point Data"
@@ -99,8 +46,8 @@ Unbinned data describes a measurement of multiple data points in a possibly mult
 
 -   `name`: custom string
 -   `type`: `unbinned`
--   `entries`: array of arrays containing the coordinates/entries of the data
--   `axes`: array of axis structs. Each struct [must]{.smallcaps} be a valid continuous or categorical axis as defined in [Axis Specifications](#sec:axes). Binning fields (`nbins`, `edges`) [must not]{.smallcaps} be present.
+-   `entries`: array of arrays containing the coordinates/entries of the data. For a categorical axis, the corresponding column holds the respective row's category as one of the strings listed in `categories`.
+-   `axes`: array of continuous or categorical axes as defined in [Axis Specifications](#sec:axes).
 -   `weights`: ([optional]{.smallcaps}) array of values containing the weights of the individual data points, to be used for $\chi^2$ comparisons and fits. If this component is not given, weight 1 is assumed for all data points. If given, the array needs to be of the same length as `entries`.
 -   `entries_uncertainties`: ([optional]{.smallcaps}) array of arrays containing the errors/uncertainties of each entry. If given, the array needs to be of the same shape as `entries`.
 
@@ -142,10 +89,8 @@ Binned data describes a histogram of data points with bin contents in a possibly
 
 -   `name`: custom string
 -   `type`: `binned`
--   `contents`: array of values representing the contents of the binned data set
--   `axes`: array of axis structs. Each struct [must]{.smallcaps} be a valid continuous or categorical axis as defined in [Axis Specifications](#sec:axes). Each continuous axis [must]{.smallcaps} carry exactly one binning specification:
-    1.  Regular binning: `nbins` (number of equal-width bins)
-    2.  Irregular binning: `edges` (array of length $n+1$ bin boundaries)
+-   `contents`: array of values representing the contents of the binned data set, flattened as defined in [Flattening of Binned Contents](#sec:axes-flattening)
+-   `axes`: array of binned or categorical axes as defined in [Axis Specifications](#sec:axes)
 -   `uncertainty`: ([optional]{.smallcaps}) struct representing the uncertainty of the contents. It consists of up to three components:
     -   `type`: denoting the kind of uncertainty, for now only Gaussian distributed uncertainties denoted as `gaussian_uncertainty` are supported
     -   `sigma`: array of the standard deviation of the entries in `contents`. Needs to be of the same length as `contents`

--- a/docs/chapters/2.3_data.md
+++ b/docs/chapters/2.3_data.md
@@ -18,6 +18,10 @@ While data, in most settings, has no uncertainty attached to it, this standard *
 
 While it should always be preferred to publish "raw" data, allowing to include pre-processed data with corresponding uncertainties expands the possible applications considerably.
 
+Data sets associate their contents with variables via `axes`. Depending on the type of data set, these are continuous, binned or categorical axes, as specified in [Axis Specifications](#sec:axes).
+
+**Forbidden attributes**: The `const` attribute [must not]{.smallcaps} appear in the `axes` of data sets. All axes of data sets define observable domains, never fit parameters.
+
 ### Point Data
 Point data describes a measurement of a single number, with a possible uncertainty (error).
 

--- a/docs/chapters/2.5_domains.md
+++ b/docs/chapters/2.5_domains.md
@@ -8,14 +8,7 @@ The top-level component `domains` contains an array of domains giving informatio
 
 -   `name`: custom string 
 -   `type`: `product_domain` 
--   `axes`: array of parameters and variables in this domain in terms of individual axes. These can be continuous or categorical, mirroring the axis types defined in [Axis Specifications](#sec:axes){reference-type="ref" reference="sec:axes"}.
-    -   A continuous axis has the components:  
-        -   `name`: custom string
-        -   `max`: upper bound of range 
-        -   `min`: lower bound of range.
-    -   A categorical axis has the components: 
-        - `name`: custom string
-        - `categories`: array of unique strings enumerating the allowed values
+-   `axes`: array of the parameters and variables in this domain, each given as a continuous or categorical axis (see [Axis Specifications](#sec:axes){reference-type="ref" reference="sec:axes"})
 
 ```json title="Example: Domains"
 "domains":[ 

--- a/docs/chapters/3.3_axes.md
+++ b/docs/chapters/3.3_axes.md
@@ -1,0 +1,58 @@
+---
+bibliography: hs3.bib
+---
+
+
+## Axis Specifications {#sec:axes}
+Axes define the observable domain for data and PDFs. Every axis is either continuous or categorical. The kind of an axis is determined structurally: an axis struct [must]{.smallcaps} contain exactly one of the field pair `min`/`max` (continuous axis) or the field `categories` (categorical axis). A continuous axis that additionally carries a binning specification is a binned axis. Wherever `axes` appear in this standard, the permitted kinds of axes are stated there.
+
+### Continuous Axes {#sec:axes-continuous}
+A continuous axis describes a real-valued observable. All continuous axes [must]{.smallcaps} include:
+
+-   `name`: identifier matching the observable in the PDF
+-   `min`: lower bound of the observable domain
+-   `max`: upper bound of the observable domain
+
+These fields define the domain over which PDFs are normalized. Where continuous axes are permitted, the binning fields (`nbins`, `edges`) [must not]{.smallcaps} be present.
+
+**Note on normalization**: Any PDF depending on a continuous observable $x$ must be normalized over the domain $[\text{min}, \text{max}]$ defined by that observable's axis, not over $(-\infty, \infty)$.
+
+### Binned Axes {#sec:axes-binned}
+A binned axis is a continuous axis that additionally carries exactly one binning specification:
+
+1. Regular binning: `nbins` (integer number of equal-width bins)
+2. Irregular binning: `edges` (array of length $n+1$ bin boundaries)
+
+Both `nbins` and `edges` [must not]{.smallcaps} be specified simultaneously, and one of them [must]{.smallcaps} be present.
+
+For irregular binning, the `edges` array must satisfy:
+
+-   `edges[0] == min`
+-   `edges[-1] == max`
+-   All values must be in strictly ascending order
+
+### Categorical Axes {#sec:axes-categorical}
+A categorical axis describes a discrete-valued observable that takes one of a finite set of named states. A categorical axis [must]{.smallcaps} include:
+
+- `name`: identifier matching the categorical observable in the PDF
+- `categories`: array of unique strings enumerating the allowed values. `categories` defines a set: the order in which values appear in the array [must not]{.smallcaps} affect evaluation.
+
+The `categories` array itself defines the domain of the axis; the fields `min`, `max`, `nbins` and `edges` [must not]{.smallcaps} be present.
+
+Where categorical axes are permitted alongside binned axes, a categorical axis acts as its own binning, with one bin per category in the order given by `categories`.
+
+### Forbidden Attributes
+The `const` attribute [must not]{.smallcaps} appear in axis specifications. All axes define observable domains, never fit parameters.
+
+### Flattening of Binned Contents {#sec:axes-flattening}
+For binned data with axes $a_0, \ldots, a_{d-1}$, listed in this order in `axes`, with $N_j$ bins each, `contents` has length $\prod_{j=0}^{d-1} N_j$. Bins along each axis are indexed from $0$ in ascending order (for categorical axes, in the order given by `categories`). The content of the bin with indices $(i_0, \ldots, i_{d-1})$ is stored at position
+
+
+
+$$
+k = \sum_{j=0}^{d-1} i_j \prod_{m=j+1}^{d-1} N_m ,
+$$
+
+
+
+i.e. the last axis listed in `axes` varies fastest. For example, for two axes with $N_0 = 2$ and $N_1 = 3$, `contents` lists the bins $(0,0), (0,1), (0,2), (1,0), (1,1), (1,2)$ in this order. The same order applies to any other array holding one value per bin.

--- a/docs/chapters/3.3_axes.md
+++ b/docs/chapters/3.3_axes.md
@@ -4,14 +4,14 @@ bibliography: hs3.bib
 
 
 ## Axis Specifications {#sec:axes}
-Axes define the observable domain for data and PDFs. Every axis is either continuous or categorical. The kind of an axis is determined structurally: an axis struct [must]{.smallcaps} contain exactly one of the field pair `min`/`max` (continuous axis) or the field `categories` (categorical axis). A continuous axis that additionally carries a binning specification is a binned axis. Wherever `axes` appear in this standard, the permitted kinds of axes are stated there.
+Axes define the domains of variables. Every axis is either continuous or categorical. The kind of an axis is determined structurally: an axis struct [must]{.smallcaps} contain exactly one of the field pair `min`/`max` (continuous axis) or the field `categories` (categorical axis). A continuous axis that additionally carries a binning specification is a binned axis. Wherever `axes` appear in this standard, the permitted kinds of axes are stated there.
 
 ### Continuous Axes {#sec:axes-continuous}
-A continuous axis describes a real-valued observable. All continuous axes [must]{.smallcaps} include:
+A continuous axis describes a real-valued variable. All continuous axes [must]{.smallcaps} include:
 
--   `name`: identifier matching the observable in the PDF
--   `min`: lower bound of the observable domain
--   `max`: upper bound of the observable domain
+-   `name`: identifier matching the variable in the PDF
+-   `min`: lower bound of the domain
+-   `max`: upper bound of the domain
 
 These fields define the domain over which PDFs are normalized. Where continuous axes are permitted, the binning fields (`nbins`, `edges`) [must not]{.smallcaps} be present.
 
@@ -32,17 +32,14 @@ For irregular binning, the `edges` array must satisfy:
 -   All values must be in strictly ascending order
 
 ### Categorical Axes {#sec:axes-categorical}
-A categorical axis describes a discrete-valued observable that takes one of a finite set of named states. A categorical axis [must]{.smallcaps} include:
+A categorical axis describes a discrete-valued variable that takes one of a finite set of named states. A categorical axis [must]{.smallcaps} include:
 
-- `name`: identifier matching the categorical observable in the PDF
+- `name`: identifier matching the categorical variable in the PDF
 - `categories`: array of unique strings enumerating the allowed values. `categories` defines a set: the order in which values appear in the array [must not]{.smallcaps} affect evaluation.
 
 The `categories` array itself defines the domain of the axis; the fields `min`, `max`, `nbins` and `edges` [must not]{.smallcaps} be present.
 
 Where categorical axes are permitted alongside binned axes, a categorical axis acts as its own binning, with one bin per category in the order given by `categories`.
-
-### Forbidden Attributes
-The `const` attribute [must not]{.smallcaps} appear in axis specifications. All axes define observable domains, never fit parameters.
 
 ### Flattening of Binned Contents {#sec:axes-flattening}
 For binned data with axes $a_0, \ldots, a_{d-1}$, listed in this order in `axes`, with $N_j$ bins each, `contents` has length $\prod_{j=0}^{d-1} N_j$. Bins along each axis are indexed from $0$ in ascending order (for categorical axes, in the order given by `categories`). The content of the bin with indices $(i_0, \ldots, i_{d-1})$ is stored at position

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,5 +58,7 @@ title: HS3
 
 {% include-markdown "chapters/3.2_authoring_primitives.md" %}
 
+{% include-markdown "chapters/3.3_axes.md" %}
+
 # References 
 \bibliography

--- a/docs/parts/histfactory.md
+++ b/docs/parts/histfactory.md
@@ -130,8 +130,7 @@ The components of a HistFactory distribution are:
     
 -   `name`: custom unique string 
 -   `type`: `histfactory_dist` 
--   `axes`: array of structs representing the axes. If given each struct     needs to have the component `name`. Further,     ([optional]{.smallcaps}) components are `max`, `min` and `nbins`,     or, alternatively, `edges`. The definition of the axes follows the     format for binned data (see Section 
-    [Binned Data](#sec:binned-data){reference-type="ref"     reference="sec:binned-data"}). 
+-   `axes`: array of binned axes as defined in [Binned Axes](#sec:axes-binned){reference-type="ref" reference="sec:axes-binned"}. All arrays holding one value per bin, such as the `contents` and `errors` of the samples and the per-bin data of the modifiers, are flattened as defined in [Flattening of Binned Contents](#sec:axes-flattening){reference-type="ref" reference="sec:axes-flattening"}.
 -   `default_interpolation`: [optional]{.smallcaps} struct defining the default interpolation behaviour, for modifiers that do not specify it on their own. It has the components `type`, `in` and `out`, as described above.
 -   `samples`: array of structs containing the samples of this channel.     For details see below. 
 Struct of one sample:  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
       - Supplementary: chapters/3_supplementary.md
       - Generic Expressions: chapters/3.1_generic_expressions.md
       - Authoring Primitives: chapters/3.2_authoring_primitives.md
+      - Axes: chapters/3.3_axes.md
   - PDF version: files/hs3.pdf
     
 


### PR DESCRIPTION
## Summary

Moves the axis specification from the data chapter into a new normative appendix section, *Axis Specifications*, and defines the storage order of multi-dimensional binned `contents`, which was previously unspecified. 
For axes $a_0, \ldots, a_{d-1}$ in the order of `axes`, with $N_j$ bins each, bin $(i_0, \ldots, i_{d-1})$ is stored at

$$
k(i_0, \ldots, i_{d-1}) = \sum_{j=0}^{d-1} i_j \prod_{m=j+1}^{d-1} N_m ,
$$

i.e. the last axis varies fastest. 

#### What changed
- `3.3_axes.md` (new): *Continuous Axes*, *Binned Axes*, *Categorical Axes*, *Flattening of Binned Contents*. Text moved from `2.3_data.md`; `#sec:axes` kept.
  - Categories are identified by name; their position in `categories` only matters for the storage layout of binned `contents`
- `2.3_data.md`, `2.5_domains.md`, `2.1.2_composite_distributions.md`: state the allowed kinds of axes and link to the appendix.
- `parts/histfactory.md`: per-bin arrays follow the flattening rule; `axes` requirements unchanged (tightened in #124).

> **Note**: #124 will have a one-line conflict in the HistFactory `axes` bullet after : keep its tightened wording plus the flattening sentence; i.e. merge 124 first, then resolve conflict here.